### PR TITLE
Phase 0 + Phase 1: make fog-node runnable and bring core data model to FOG 1.6 parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,55 @@
 # fog-node
-This is the FOG 2.0 parent repository.
 
-Work in Progress
+This is the FOG 2.0 parent repository — a Node.js ([Sails.js](https://sailsjs.com))
+rewrite of the FOG Project server, backed by MongoDB.
 
-1. Install nodejs
-2. Install mongo
- Recommend configuring user and password.
-3. Download the repository using `git`
- `git clone https://github.com/fogproject/fog-node`
-4. Change to the directory you just downloaded the repo to:
- `cd fog-node`
-5. Install the modules needed
- `npm install`
-6. Run the setup for fresh install:
- `node tools/setup/index.js`
-6. Enter the information as required/requested.
-7. Lift the server with `sails lift`
-6. Enjoy.
+> **Work in progress.** See [docs/roadmap.md](docs/roadmap.md) for the current
+> state and the plan toward feature parity with FOG 1.6.
+
+## Requirements
+
+- **Node.js** — tested on Node 22 (LTS) and Node 26.
+- **MongoDB** — 7.x recommended.
+
+## Development quickstart
+
+A fresh clone can be brought up in four steps:
+
+```sh
+# 1. Install dependencies
+npm install
+
+# 2. Start a development MongoDB (no auth — dev only)
+docker compose up -d        # or: podman compose up -d
+# No compose plugin? Run Mongo directly:
+#   podman run -d --name fog-node-mongo -p 127.0.0.1:27017:27017 docker.io/library/mongo:7
+
+# 3. Write dev config + seed the Administrator account (non-interactive)
+npm run setup:dev
+
+# 4. Start the server
+npm start                   # or: node app.js
+```
+
+Then browse to <http://localhost:1337> and log in as `Administrator`
+(default password `fogadmin1` — change it, or override at setup time).
+
+`setup:dev` writes the git-ignored `config/local.js` and `config/models.js`
+with localhost defaults. Override any of them via env vars (see the header of
+[tools/setup/dev.js](tools/setup/dev.js)), e.g.:
+
+```sh
+FOG_DEV_ADMIN_PASSWORD='supersecret' FOG_DEV_DB_NAME='fogdev' npm run setup:dev
+```
+
+## Production install
+
+For a real install, run the interactive installer instead of `setup:dev`:
+
+```sh
+node tools/setup/index.js   # prompts for DB, admin account, webserver, etc.
+npm start                   # NODE_ENV=production node app.js
+```
 
 TODO:
  Build views for all the different components

--- a/api/hooks/watchdog/index.js
+++ b/api/hooks/watchdog/index.js
@@ -17,12 +17,15 @@ module.exports = function defineWatchdogHook(sails) {
       running = true;
       sails.log.info('Starting watchdog');
       sails.emit('fog:watchdog:start');
+      // NOTE: the iteratee must be a plain (non-async) function. Under async@3
+      // an async/promise-returning iteratee is not passed the `next` callback,
+      // which made `setTimeout(next, delay)` throw (next === undefined).
       async.forever(
-        async (next) => {
+        (next) => {
           sails.emit('fog:watchdog:tick');
           setTimeout(next, delay);
         },
-        async (err) => {
+        (err) => {
           running = false;
           sails.emit('fog:watchdog:crash');
           sails.log.error(`Watchdog crashed, err: ${err}`);

--- a/api/models/Group.js
+++ b/api/models/Group.js
@@ -27,6 +27,16 @@ module.exports = {
     },
     image: {
       model: 'image'
+    },
+    snapins: {
+      collection: 'snapin',
+      via: 'groups',
+      dominant: true
+    },
+    printers: {
+      collection: 'printer',
+      via: 'groups',
+      dominant: true
     }
   }
 };

--- a/api/models/Host.js
+++ b/api/models/Host.js
@@ -24,6 +24,94 @@ module.exports = {
     macs: {
       type: 'json'
     },
+    // --- FOG 1.x `hosts` scalar fields (friendly names; snake_case
+    //     security fields normalised to camelCase) ---
+    ip: {
+      type: 'string'
+    },
+    building: {
+      type: 'number',
+      isInteger: true,
+      defaultsTo: 0
+    },
+    deployed: {
+      type: 'string'
+    },
+    createdBy: {
+      type: 'string'
+    },
+    useAD: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    ADDomain: {
+      type: 'string'
+    },
+    ADOU: {
+      type: 'string'
+    },
+    ADUser: {
+      type: 'string'
+    },
+    ADPass: {
+      type: 'string'
+    },
+    ADPassLegacy: {
+      type: 'string'
+    },
+    productKey: {
+      type: 'string'
+    },
+    printerLevel: {
+      type: 'number',
+      isInteger: true,
+      defaultsTo: 0
+    },
+    kernelArgs: {
+      type: 'string'
+    },
+    kernel: {
+      type: 'string'
+    },
+    kernelDevice: {
+      type: 'string'
+    },
+    init: {
+      type: 'string'
+    },
+    pending: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    pubKey: {
+      type: 'string'
+    },
+    secToken: {
+      type: 'string'
+    },
+    secTime: {
+      type: 'string'
+    },
+    pingstatus: {
+      type: 'string'
+    },
+    biosexit: {
+      type: 'string'
+    },
+    efiexit: {
+      type: 'string'
+    },
+    enforce: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    token: {
+      type: 'string'
+    },
+    tokenlock: {
+      type: 'boolean',
+      defaultsTo: false
+    },
     image: {
       model: 'image'
     },

--- a/api/models/Host.js
+++ b/api/models/Host.js
@@ -122,6 +122,19 @@ module.exports = {
     workflows: {
       collection: 'workflow',
       via: 'host'
+    },
+    snapins: {
+      collection: 'snapin',
+      via: 'hosts',
+      dominant: true
+    },
+    printers: {
+      collection: 'printer',
+      via: 'hosts',
+      dominant: true
+    },
+    defaultPrinter: {
+      model: 'printer'
     }
   }
 };

--- a/api/models/Image.js
+++ b/api/models/Image.js
@@ -36,6 +36,56 @@ module.exports = {
       type: 'string',
       columnType: 'datetime'
     },
+    // --- FOG 1.x `images` scalar fields. The lookup FKs (imageType,
+    //     imagePartitionType, os) are kept as numeric ids for now; dedicated
+    //     ImageType/PartitionType/OS models can replace them later. ---
+    path: {
+      type: 'string'
+    },
+    createdBy: {
+      type: 'string'
+    },
+    building: {
+      type: 'number',
+      isInteger: true,
+      defaultsTo: 0
+    },
+    size: {
+      type: 'string'
+    },
+    srvsize: {
+      type: 'string'
+    },
+    imageType: {
+      type: 'number',
+      isInteger: true
+    },
+    imagePartitionType: {
+      type: 'number',
+      isInteger: true
+    },
+    os: {
+      type: 'number',
+      isInteger: true
+    },
+    deployed: {
+      type: 'string'
+    },
+    format: {
+      type: 'number',
+      isInteger: true
+    },
+    magnet: {
+      type: 'string'
+    },
+    compress: {
+      type: 'number',
+      isInteger: true
+    },
+    toReplicate: {
+      type: 'boolean',
+      defaultsTo: true
+    },
     hosts: {
       collection: 'host',
       via: 'image'

--- a/api/models/Printer.js
+++ b/api/models/Printer.js
@@ -35,6 +35,14 @@ module.exports = {
     },
     ip: {
       type: 'string'
+    },
+    hosts: {
+      collection: 'host',
+      via: 'printers'
+    },
+    groups: {
+      collection: 'group',
+      via: 'printers'
     }
   }
 };

--- a/api/models/Printer.js
+++ b/api/models/Printer.js
@@ -1,0 +1,40 @@
+/**
+ * Printer.js
+ *
+ * @description :: A printer definition that can be assigned to hosts/groups.
+ *                 Mirrors FOG 1.x `printers`.
+ * @docs        :: https://sailsjs.com/docs/concepts/models-and-orm/models
+ */
+module.exports = {
+  attributes: {
+    name: {
+      type: 'string',
+      required: true,
+      unique: true
+    },
+    description: {
+      type: 'string'
+    },
+    port: {
+      type: 'string'
+    },
+    file: {
+      type: 'string'
+    },
+    // NOTE: named `printerModel`, not `model`, on purpose. The generic CRUD
+    // routes are `/api/v1/:model`, so `req.allParams().model` is the route's
+    // model identity and would clobber a body field literally named `model`.
+    printerModel: {
+      type: 'string'
+    },
+    config: {
+      type: 'string'
+    },
+    configFile: {
+      type: 'string'
+    },
+    ip: {
+      type: 'string'
+    }
+  }
+};

--- a/api/models/PxeMenu.js
+++ b/api/models/PxeMenu.js
@@ -1,0 +1,41 @@
+/**
+ * PxeMenu.js
+ *
+ * @description :: A PXE/iPXE boot-menu entry. Mirrors FOG 1.x `pxeMenuOptions`
+ *                 (the sidebar's "iPXE Menu"). The separate 1.x `ipxe`
+ *                 hardware-mapping table is intentionally not modelled yet.
+ * @docs        :: https://sailsjs.com/docs/concepts/models-and-orm/models
+ */
+module.exports = {
+  attributes: {
+    name: {
+      type: 'string',
+      required: true,
+      unique: true
+    },
+    description: {
+      type: 'string'
+    },
+    params: {
+      type: 'string'
+    },
+    default: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    regMenu: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    args: {
+      type: 'string'
+    },
+    hotkey: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    keysequence: {
+      type: 'string'
+    }
+  }
+};

--- a/api/models/Snapin.js
+++ b/api/models/Snapin.js
@@ -1,0 +1,75 @@
+/**
+ * Snapin.js
+ *
+ * @description :: A deployable software package / script. Mirrors FOG 1.x
+ *                 `snapins`. (The sidebar currently labels these "Modules".)
+ * @docs        :: https://sailsjs.com/docs/concepts/models-and-orm/models
+ */
+module.exports = {
+  attributes: {
+    name: {
+      type: 'string',
+      required: true,
+      unique: true
+    },
+    description: {
+      type: 'string'
+    },
+    file: {
+      type: 'string'
+    },
+    args: {
+      type: 'string'
+    },
+    reboot: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    shutdown: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    runWith: {
+      type: 'string'
+    },
+    runWithArgs: {
+      type: 'string'
+    },
+    protected: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    isEnabled: {
+      type: 'boolean',
+      defaultsTo: true
+    },
+    toReplicate: {
+      type: 'boolean',
+      defaultsTo: true
+    },
+    hide: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    timeout: {
+      type: 'number',
+      isInteger: true,
+      min: 0,
+      defaultsTo: 0
+    },
+    packtype: {
+      type: 'number',
+      isInteger: true,
+      defaultsTo: 0
+    },
+    hash: {
+      type: 'string'
+    },
+    size: {
+      type: 'string'
+    },
+    createdBy: {
+      type: 'string'
+    }
+  }
+};

--- a/api/models/Snapin.js
+++ b/api/models/Snapin.js
@@ -70,6 +70,14 @@ module.exports = {
     },
     createdBy: {
       type: 'string'
+    },
+    hosts: {
+      collection: 'host',
+      via: 'snapins'
+    },
+    groups: {
+      collection: 'group',
+      via: 'snapins'
     }
   }
 };

--- a/api/models/StorageGroup.js
+++ b/api/models/StorageGroup.js
@@ -1,0 +1,22 @@
+/**
+ * StorageGroup.js
+ *
+ * @description :: A logical group of storage nodes. Mirrors FOG 1.x `nfsGroups`.
+ * @docs        :: https://sailsjs.com/docs/concepts/models-and-orm/models
+ */
+module.exports = {
+  attributes: {
+    name: {
+      type: 'string',
+      required: true,
+      unique: true
+    },
+    description: {
+      type: 'string'
+    },
+    storageNodes: {
+      collection: 'storagenode',
+      via: 'storagegroup'
+    }
+  }
+};

--- a/api/models/StorageNode.js
+++ b/api/models/StorageNode.js
@@ -1,0 +1,88 @@
+/**
+ * StorageNode.js
+ *
+ * @description :: A storage node (member) within a storage group. Mirrors FOG
+ *                 1.x `nfsGroupMembers`.
+ * @docs        :: https://sailsjs.com/docs/concepts/models-and-orm/models
+ */
+module.exports = {
+  attributes: {
+    name: {
+      type: 'string'
+    },
+    description: {
+      type: 'string'
+    },
+    isMaster: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    isEnabled: {
+      type: 'boolean',
+      defaultsTo: true
+    },
+    isGraphEnabled: {
+      type: 'boolean',
+      defaultsTo: true
+    },
+    ip: {
+      type: 'string',
+      required: true
+    },
+    path: {
+      type: 'string',
+      required: true
+    },
+    ftppath: {
+      type: 'string',
+      required: true
+    },
+    snapinpath: {
+      type: 'string'
+    },
+    sslpath: {
+      type: 'string'
+    },
+    webroot: {
+      type: 'string'
+    },
+    user: {
+      type: 'string',
+      required: true
+    },
+    pass: {
+      type: 'string',
+      required: true
+    },
+    key: {
+      type: 'string'
+    },
+    interface: {
+      type: 'string'
+    },
+    maxClients: {
+      type: 'number',
+      isInteger: true,
+      min: 0,
+      defaultsTo: 10
+    },
+    bitrate: {
+      type: 'string'
+    },
+    bandwidth: {
+      type: 'string'
+    },
+    helloInterval: {
+      type: 'number',
+      isInteger: true,
+      min: 0,
+      defaultsTo: 10
+    },
+    graphcolor: {
+      type: 'string'
+    },
+    storagegroup: {
+      model: 'storagegroup'
+    }
+  }
+};

--- a/config/permissions.js
+++ b/config/permissions.js
@@ -77,6 +77,12 @@ module.exports.permissions = {
       destroy: false,
       read: false,
       update: false
+    },
+    pxemenu: {
+      create: false,
+      destroy: false,
+      read: false,
+      update: false
     }
   }
 };

--- a/config/permissions.js
+++ b/config/permissions.js
@@ -53,6 +53,30 @@ module.exports.permissions = {
       destroy: false,
       read: false,
       update: false
+    },
+    storagegroup: {
+      create: false,
+      destroy: false,
+      read: false,
+      update: false
+    },
+    storagenode: {
+      create: false,
+      destroy: false,
+      read: false,
+      update: false
+    },
+    snapin: {
+      create: false,
+      destroy: false,
+      read: false,
+      update: false
+    },
+    printer: {
+      create: false,
+      destroy: false,
+      read: false,
+      update: false
     }
   }
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+# Development MongoDB for fog-node.
+#
+# This is for LOCAL DEVELOPMENT ONLY -- it runs Mongo with no authentication,
+# matching the default connection string written by `npm run setup:dev`
+# (mongodb://127.0.0.1:27017/fog). Do not use this for production.
+#
+# Works with either Docker or Podman:
+#   docker compose up -d        (or)   podman compose up -d
+#   docker compose down                podman compose down
+#
+services:
+  mongo:
+    image: mongo:7
+    container_name: fog-node-mongo
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:27017:27017"
+    volumes:
+      - fog-node-mongo-data:/data/db
+
+volumes:
+  fog-node-mongo-data:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,15 +45,16 @@ more than exists. None of the following have models/controllers/views yet:
 `tools/migrate/` is a Mongo *schema-revision* framework, **not** a 1.x-MySQL →
 2.0 data importer; that importer does not exist yet.
 
-## Open decisions (gate detailed planning of Phases 2+)
+## Decisions
 
-1. **Client / FOS compatibility** — must fog-node speak the *existing*
-   fog-client and FOS (iPXE/imaging) APIs so current clients keep working, or are
-   the client/FOS being rewritten alongside 2.0? This shapes the entire imaging
-   and host-registration surface.
-2. **Frontend direction** — `package.json` currently carries Vue 3 *and* React 19
-   *and* jQuery 4 *and* parasails *and* DataTables; the EJS layout references some
-   vendored files that aren't installed. One stack needs to be chosen.
+1. **Client / FOS compatibility** — *decided: mirror 1.x fields now, settle the
+   live protocol at Phase 2.* Entities are modelled on 1.x's schema (compatible-
+   leaning); the actual capture/deploy/registration protocol is decided when
+   imaging is built.
+2. **Frontend direction** — *decided: server-rendered EJS + jQuery / DataTables /
+   AdminLTE* (matches 1.x, no build step, what the existing pages use). The
+   half-present Vue 3 / React 19 deps should be removed (follow-up). Views are
+   built per-entity on top of the API/model layer.
 
 ## Phases
 
@@ -86,16 +87,23 @@ automatically gets full REST CRUD via the generic `:model` routes once it has a
 - [x] `Printer` — mirrors 1.x `printers`. NOTE: the 1.x `pModel` field is exposed
       as `printerModel`, not `model`, because the generic route param `:model`
       would otherwise clobber a body field named `model`.
-- [ ] **iPXE menu — deferred (needs a decision):** in 1.x this splits into two
-      tables — `pxemenuoptions` (the boot-menu entries admins create) and `ipxe`
-      (a hardware product/manufacturer/MAC → boot-file mapping). Which one the
-      sidebar's "iPXE Menu" represents (and the model name) needs to be decided.
-- [ ] Host↔Snapin / Host↔Printer / Group associations (1.x association tables).
-- [ ] Flesh out `Host`/`Image`/`Task` to carry 1.x's fields (gated partly by the
-      client/FOS compatibility decision).
+- [x] `PxeMenu` — mirrors 1.x `pxeMenuOptions` (the sidebar's "iPXE Menu"). The
+      separate 1.x `ipxe` product/manufacturer/MAC → boot-file mapping table is
+      deferred until the boot/imaging flow needs it.
+- [x] `Host` + `Image` scalar field parity with 1.x (AD, kernel, product key,
+      pending, security tokens, etc. on Host; path/type/partition/os/format/
+      compress/etc. on Image). Existing fog-node fields/associations preserved.
+      Image lookup FKs (`imageType`/`imagePartitionType`/`os`) kept as numeric
+      ids for now.
+- [ ] Host↔Snapin / Host↔Printer / Group associations (1.x association tables);
+      Host "default printer" (1.x `printerAssoc.isDefault`).
+- [ ] `Task` field parity (gated partly by the client/FOS decision).
+- [ ] Lookup models to replace numeric FKs: ImageType, PartitionType, OS.
 - [ ] Seed the `FOG_*` settings 1.x expects.
-- [ ] Page controllers/views for the new entities (gated by the frontend-stack
-      decision).
+- [ ] Page controllers/views for the new entities (EJS + jQuery, per the frontend
+      decision); reconcile the sidebar (`config/globals.js`) labels/routes with the
+      model identities (e.g. "Modules" → snapin, plural view routes).
+- [ ] Remove the unused Vue 3 / React 19 dependencies (frontend decision).
 
 ### Phase 2 — Imaging end-to-end  *(the heart of FOG)*
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,12 +72,30 @@ more than exists. None of the following have models/controllers/views yet:
 - [ ] Resolve the lockfile split (`yarn.lock` is committed while
       `package-lock.json` keeps reappearing untracked). Pick one tool.
 
-### Phase 1 — Data-model parity for core entities  *(foundation)*
+### Phase 1 — Data-model parity for core entities  *(in progress)*
 
-Add missing models + fields and wire them into routes / CRUD / views:
-StorageGroup, StorageNode, Module (Snapin), iPXE menu, Printer. Flesh out
-`Host`/`Image`/`Task`/`Setting` to carry 1.x's fields. Seed the `FOG_*` settings
-1.x expects.
+Add the missing core entity models (mirroring 1.x fields). Each registered model
+automatically gets full REST CRUD via the generic `:model` routes once it has a
+`stock.<identity>` entry in `config/permissions.js`.
+
+- [x] `StorageGroup` + `StorageNode` (with a bidirectional association) —
+      mirrors 1.x `nfsGroups` / `nfsGroupMembers`.
+- [x] `Snapin` — mirrors 1.x `snapins`. (The sidebar labels these "Modules"; the
+      model is named `Snapin` to match 1.x domain language and avoid shadowing
+      Node's `Module` global. Sidebar label/route to be reconciled later.)
+- [x] `Printer` — mirrors 1.x `printers`. NOTE: the 1.x `pModel` field is exposed
+      as `printerModel`, not `model`, because the generic route param `:model`
+      would otherwise clobber a body field named `model`.
+- [ ] **iPXE menu — deferred (needs a decision):** in 1.x this splits into two
+      tables — `pxemenuoptions` (the boot-menu entries admins create) and `ipxe`
+      (a hardware product/manufacturer/MAC → boot-file mapping). Which one the
+      sidebar's "iPXE Menu" represents (and the model name) needs to be decided.
+- [ ] Host↔Snapin / Host↔Printer / Group associations (1.x association tables).
+- [ ] Flesh out `Host`/`Image`/`Task` to carry 1.x's fields (gated partly by the
+      client/FOS compatibility decision).
+- [ ] Seed the `FOG_*` settings 1.x expects.
+- [ ] Page controllers/views for the new entities (gated by the frontend-stack
+      decision).
 
 ### Phase 2 — Imaging end-to-end  *(the heart of FOG)*
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,98 @@
+# fog-node roadmap
+
+fog-node is **"FOG 2.0"** — a from-scratch [Sails.js](https://sailsjs.com)
+(Node.js) rewrite of the FOG Project server, backed by MongoDB. It is **not** a
+port of the PHP FOG 1.x codebase: it re-architects the domain (e.g. a
+`Workflow` abstraction with no 1.x equivalent, generic `:model` CRUD, Sails
+associations in place of 1.x's explicit association tables, "Module" as the
+snapin analog). "Catching up to 1.6" therefore means *reimplementation*, never a
+code merge.
+
+This document tracks where the rewrite stands and the plan toward feature parity
+with FOG 1.6.
+
+## Current state
+
+**Runtime works.** With MongoDB available and setup run, the app lifts cleanly on
+both Node 22 and Node 26 (`Server lifted`, port 1337). The status API, local +
+JWT auth, and the seeded Administrator account are functional.
+
+**Implemented today:**
+
+- 8 models: `Host`, `Image`, `Group`, `Role`, `Setting`, `Task`, `User`,
+  `Workflow`.
+- Generic CRUD driven by a `:model` route param (`api/controllers/general/*`),
+  plus DataTables list/columns endpoints.
+- Auth: passport local + JWT (cookiecombo) with a granular per-model permissions
+  system (`config/permissions.js`, `Role`/`User` models).
+- EJS pages for dashboard, list, create, login, hwinfo.
+- Custom hooks: `fog-version`, `watchdog` (the seed of the future task runner).
+- Interactive installer (`tools/setup/index.js`) and a non-interactive dev setup
+  (`tools/setup/dev.js`).
+
+**Gap vs. FOG 1.6 (large).** The sidebar (`config/globals.js`) advertises much
+more than exists. None of the following have models/controllers/views yet:
+
+- Storage Groups, Storage Nodes (core to imaging & replication)
+- Modules/Snapins, Printers, iPXE menus
+- Multicast, Pending Hosts / Pending MACs (host approval)
+- Import/Export for every entity
+- A real imaging engine (capture/deploy controllers are stubs)
+- The 1.x background daemons (TaskScheduler, Image/Snapin replicators,
+  MulticastManager, PingHosts, ImageSize, SnapinHash, FileDeleter)
+- The hundreds of `FOG_*` global settings 1.x seeds
+
+`tools/migrate/` is a Mongo *schema-revision* framework, **not** a 1.x-MySQL →
+2.0 data importer; that importer does not exist yet.
+
+## Open decisions (gate detailed planning of Phases 2+)
+
+1. **Client / FOS compatibility** — must fog-node speak the *existing*
+   fog-client and FOS (iPXE/imaging) APIs so current clients keep working, or are
+   the client/FOS being rewritten alongside 2.0? This shapes the entire imaging
+   and host-registration surface.
+2. **Frontend direction** — `package.json` currently carries Vue 3 *and* React 19
+   *and* jQuery 4 *and* parasails *and* DataTables; the EJS layout references some
+   vendored files that aren't installed. One stack needs to be chosen.
+
+## Phases
+
+### Phase 0 — Make "run" reliable & reproducible  *(in progress)*
+
+- [x] Fix the `watchdog` hook crash (`async.forever` given an async iteratee —
+      broke under `async@3`).
+- [x] One-command dev MongoDB (`docker-compose.yml`).
+- [x] Non-interactive dev setup (`npm run setup:dev`).
+- [x] Document supported Node versions + dev quickstart (README).
+- [ ] Make `npm run lint` runnable again — installed `eslint@10` only supports
+      flat config, but the repo ships a v4-style `.eslintrc`. Either migrate to
+      `eslint.config.js` (and clean up the resulting warnings, since the lint
+      script runs with `--max-warnings=0`) or pin `eslint` to v8. Deferred —
+      decide the eslint direction first.
+- [ ] Resolve the lockfile split (`yarn.lock` is committed while
+      `package-lock.json` keeps reappearing untracked). Pick one tool.
+
+### Phase 1 — Data-model parity for core entities  *(foundation)*
+
+Add missing models + fields and wire them into routes / CRUD / views:
+StorageGroup, StorageNode, Module (Snapin), iPXE menu, Printer. Flesh out
+`Host`/`Image`/`Task`/`Setting` to carry 1.x's fields. Seed the `FOG_*` settings
+1.x expects.
+
+### Phase 2 — Imaging end-to-end  *(the heart of FOG)*
+
+Storage-node integration, real capture/deploy (image-lock helpers already exist),
+iPXE menu generation, host registration from FOS, progress over sockets via
+`Task`/`Workflow`.
+
+### Phase 3 — Background services
+
+Port the 1.x daemons as Sails hooks/services (the `watchdog` hook is the seed):
+task scheduler, image/snapin replication, multicast manager, ping hosts, image
+size, snapin hash, file deleter.
+
+### Phase 4+ — Breadth
+
+Snapins/modules, printers, WOL, power management, inventory, reports,
+import/export, Active Directory, plugins — then auth/settings-UI/i18n polish and
+a 1.x → 2.0 data migration path.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,8 +95,14 @@ automatically gets full REST CRUD via the generic `:model` routes once it has a
       compress/etc. on Image). Existing fog-node fields/associations preserved.
       Image lookup FKs (`imageType`/`imagePartitionType`/`os`) kept as numeric
       ids for now.
-- [ ] Host↔Snapin / Host↔Printer / Group associations (1.x association tables);
-      Host "default printer" (1.x `printerAssoc.isDefault`).
+- [x] Host↔Snapin, Host↔Printer, Group↔Snapin, Group↔Printer many-to-many
+      associations + Host `defaultPrinter` (1.x `printerAssoc.isDefault`).
+      Relationships are defined and populate via the API. **Follow-up:**
+      *assigning* members through the API needs controller support — the generic
+      `update` doesn't set collections and the blueprint nested
+      `/:model/:id/:assoc/:fk` routes are shadowed by the custom `:model` routes
+      (return 404). Add explicit add/remove-to-collection endpoints (mirroring
+      the existing `group/register`, `role/assign` pattern).
 - [ ] `Task` field parity (gated partly by the client/FOS decision).
 - [ ] Lookup models to replace numeric FKs: ImageType, PartitionType, OS.
 - [ ] Seed the `FOG_*` settings 1.x expects.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "scripts": {
     "start": "NODE_ENV=production node app.js",
+    "setup:dev": "node tools/setup/dev.js",
     "test": "npm run lint && npm run custom-tests && echo 'Done.'",
     "lint": "./node_modules/eslint/bin/eslint.js . --max-warnings=0 --report-unused-disable-directives && echo '✔  Your .js files look good.'",
     "custom-tests": "echo \"(No other custom tests yet.)\" && echo"
@@ -84,6 +85,6 @@
   "author": "FOG Project",
   "license": "GPL v3",
   "engines": {
-    "node": ">=10.19"
+    "node": ">=18"
   }
 }

--- a/tools/setup/dev.js
+++ b/tools/setup/dev.js
@@ -1,0 +1,130 @@
+/**
+ * Non-interactive development setup for fog-node.
+ *
+ * Mirrors `tools/setup/index.js` but takes no prompts: it writes the
+ * git-ignored `config/local.js` and `config/models.js` with sane localhost
+ * defaults (overridable via env vars) and seeds the Administrator account.
+ *
+ * Intended to pair with the bundled `docker-compose.yml` Mongo so a fresh
+ * clone can be lifted with:
+ *
+ *   docker compose up -d        # or: podman compose up -d
+ *   npm run setup:dev
+ *   npm start                   # or: node app.js
+ *
+ * Env overrides:
+ *   FOG_DEV_DB_HOST   (default 127.0.0.1)
+ *   FOG_DEV_DB_PORT   (default 27017)
+ *   FOG_DEV_DB_NAME   (default fog)
+ *   FOG_DEV_DB_USER   (default <none>)
+ *   FOG_DEV_DB_PASS   (default <none>)
+ *   FOG_DEV_ADMIN_EMAIL    (default admin@example.com)
+ *   FOG_DEV_ADMIN_PASSWORD (default fogadmin1 -- must be >= 8 chars)
+ *
+ * This is for LOCAL DEVELOPMENT ONLY. For a real install use
+ * `node tools/setup/index.js`.
+ */
+const fs = require('fs'),
+  path = require('path'),
+  config = require('../lib/config'),
+  secure = require('./lib/secure'),
+  schema = require('./lib/schema'),
+  cfgPath = path.join(config.appPath, 'config'),
+  localCfg = path.join(cfgPath, 'local.js'),
+  modelsCfg = path.join(cfgPath, 'models.js'),
+  env = process.env,
+  db = {
+    host: env.FOG_DEV_DB_HOST || '127.0.0.1',
+    port: env.FOG_DEV_DB_PORT || '27017',
+    name: env.FOG_DEV_DB_NAME || 'fog',
+    user: env.FOG_DEV_DB_USER || '',
+    pass: env.FOG_DEV_DB_PASS || ''
+  },
+  admin = {
+    email: env.FOG_DEV_ADMIN_EMAIL || 'admin@example.com',
+    password: env.FOG_DEV_ADMIN_PASSWORD || 'fogadmin1'
+  };
+
+function mongoUrl() {
+  let auth = '';
+  if (db.user.length) {
+    auth = encodeURIComponent(db.user);
+    if (db.pass.length) auth += ':' + encodeURIComponent(db.pass);
+    auth += '@';
+  }
+  return `mongodb://${auth}${db.host}:${db.port}/${encodeURIComponent(db.name)}`;
+}
+
+function writeIfMissing(file, label, contents) {
+  if (fs.existsSync(file)) {
+    console.log(`${label} already exists -- leaving it untouched (delete it to regenerate).`);
+    return;
+  }
+  fs.writeFileSync(file, contents);
+  console.log(`Wrote ${label}.`);
+}
+
+if (admin.password.length < 8) {
+  console.error('FOG_DEV_ADMIN_PASSWORD must be at least 8 characters.');
+  process.exit(1);
+}
+
+writeIfMissing(localCfg, 'config/local.js', `module.exports = {
+  auth: {
+    bcrypt: {
+      rounds: 10
+    },
+    jwt: {
+      secret: '${secure.generateSecret()}',
+      options: {
+        expiresIn: '1d'
+      },
+      session: false,
+      cookie: {
+        maxAge: 24 * 1000 * 60 * 60,
+        signed: true
+      }
+    }
+  },
+  datastores: {
+    fogdb: {
+      adapter: 'sails-mongo',
+      url: '${mongoUrl()}'
+    }
+  },
+  schema: 1
+};
+`);
+
+writeIfMissing(modelsCfg, 'config/models.js', `module.exports.models = {
+  schema: true,
+  migrate: 'alter',
+  attributes: {
+    createdAt: { type: 'number', autoCreatedAt: true },
+    updatedAt: { type: 'number', autoUpdatedAt: true },
+    id: { type: 'string', columnName: '_id' }
+  },
+  datastore: 'fogdb',
+  cascadeOnDestroy: true,
+  dataEncryptionKeys: {
+    default: '${secure.generateSecret()}'
+  }
+};
+`);
+
+console.log('Seeding Administrator account...');
+schema.generate(admin.password, admin.email, (err) => {
+  if (err) {
+    console.error(`Failed to seed database: ${err}`);
+    process.exit(1);
+  }
+  console.log('');
+  console.log('Development setup complete.');
+  console.log('  URL:      http://localhost:1337');
+  console.log('  Username: Administrator');
+  console.log(`  Email:    ${admin.email}`);
+  console.log(`  Password: ${admin.password}`);
+  console.log('');
+  console.log('Start the server with `npm start` (or `node app.js`).');
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary

Gets fog-node lifting reliably again and brings the core data model up toward FOG 1.6 parity. All changes verified against a live MongoDB (lift + REST CRUD).

### Phase 0 — runnable & reproducible
- **Fix watchdog hook crash**: `async.forever` was given an `async` (promise-returning) iteratee, so under `async@3` the iteratee received no `next` callback and `setTimeout(next, delay)` threw on every lift.
- **`docker-compose.yml`** for a one-command dev MongoDB.
- **`npm run setup:dev`** (`tools/setup/dev.js`): non-interactive dev setup that writes the git-ignored `config/local.js` + `config/models.js` and seeds the admin — no prompts.
- **README** dev quickstart; `engines.node` bumped to `>=18` (verified on Node 22 and 26).
- **`docs/roadmap.md`**: gap analysis vs 1.6 and the phased plan.

### Phase 1 — core data-model parity
- New models (all with permissions + instant REST CRUD): `StorageGroup`, `StorageNode` (+ association), `Snapin`, `Printer`, `PxeMenu` (1.x `pxeMenuOptions`).
- `Host` and `Image` brought to 1.x scalar-field parity; existing fog-node fields/associations preserved.
- Host/Group ↔ Snapin/Printer many-to-many associations + `Host.defaultPrinter`.

### Notes / follow-ups (in `docs/roadmap.md`)
- Assigning collection members over the API still needs explicit endpoints (the generic `update` doesn't set collections; blueprint nested routes are shadowed).
- Deferred pending direction: eslint flat-config migration (eslint@10), `yarn.lock` vs `package-lock.json`.
- Decisions recorded: mirror-1.6-fields-now; frontend = EJS+jQuery (drop Vue/React); iPXE menu = `pxeMenuOptions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)