### PR TITLE
fix(http): stop passport 500-ing every static asset (unstyled UI)

### DIFF
--- a/config/http.js
+++ b/config/http.js
@@ -1,7 +1,18 @@
+const passport = require('passport');
+
+// Passport's session() middleware requires an active session. Sails skips
+// session setup for asset-looking requests (see the commented isSessionDisabled
+// note in config/session.js / LOOKS_LIKE_ASSET_RX), so running passport on those
+// requests throws "Login sessions require session support" and turns every
+// CSS/JS asset into a 500 -- which renders every page unstyled. Only run the
+// passport middleware when a session is actually present.
+const onlyWithSession = (middleware) => (req, res, next) =>
+  req.session ? middleware(req, res, next) : next();
+
 module.exports.http = {
   middleware: {
-  passportInit: require('passport').initialize(),
-  passportSession: require('passport').session(),
+    passportInit: onlyWithSession(passport.initialize()),
+    passportSession: onlyWithSession(passport.session()),
     order: [
       'cookieParser',
       'session',

--- a/tools/setup/index.js
+++ b/tools/setup/index.js
@@ -106,10 +106,18 @@ async.waterfall([
     /**
      * sails http.js config.
      */
-    let rawtext = `module.exports.http = {
+    let rawtext = `const passport = require('passport');
+
+// Only run passport when a session exists. Sails skips session for asset
+// requests, so running passport.session() on those throws "Login sessions
+// require session support" and turns every CSS/JS asset into a 500.
+const onlyWithSession = (middleware) => (req, res, next) =>
+  req.session ? middleware(req, res, next) : next();
+
+module.exports.http = {
   middleware: {
-  passportInit: require('passport').initialize(),
-  passportSession: require('passport').session(),
+    passportInit: onlyWithSession(passport.initialize()),
+    passportSession: onlyWithSession(passport.session()),
     order: [
       'cookieParser',
       'session',


### PR DESCRIPTION
## Problem
The UI rendered completely unstyled because **every CSS/JS asset returned 500**.

Root cause: `config/http.js` wires `passport.session()` as global middleware, but Sails skips session setup for asset-looking requests. passport then throws `Login sessions require session support` on every asset → 500 → unstyled pages.

## Fix
Guard the passport middleware so it only runs when a session exists (i.e. not on asset requests). Applied to the committed `config/http.js` and the template the interactive installer writes (`tools/setup/index.js`).

## Verified
- All assets now serve 200 (adminlte/bootstrap/font-awesome/jquery/etc.)
- Login + authenticated API requests still work
- Zero `Login sessions require session support` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)