### PR TITLE
Sidebar list pages for new entities + clean 401 on bad login

### DIFF
--- a/api/controllers/auth/login.js
+++ b/api/controllers/auth/login.js
@@ -13,6 +13,17 @@ module.exports = {
       res = this.res;
     await passport.authenticate(sails.config.globals.authenticationMechanisms, async function(err, user, info) {
       if (err) return exits.error(err);
+      // No user => bad credentials. Return a clean 401 (JSON) or bounce back to
+      // the login form, instead of calling req.login(undefined) which throws a
+      // 500 ("Failed to serialize user into session").
+      if (!user) {
+        let message = (info && info.message) || 'Invalid username or password';
+        if (req.wantsJSON) {
+          res.status(401);
+          return res.json({message});
+        }
+        return res.redirect('/login?failed=1');
+      }
       await req.login(user, async function(err) {
         if (err) return exits.error(err);
         await jwt.sign(

--- a/api/controllers/pages/list/printers.js
+++ b/api/controllers/pages/list/printers.js
@@ -1,0 +1,36 @@
+const fs = require('fs-extra'),
+  path = require('path'),
+  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+module.exports = {
+  friendlyName: 'Printers',
+  description: 'Printer list page.',
+  inputs: {
+  },
+  exits: {
+    error: {
+      responseType: 'serverError'
+    },
+    success: {
+      viewTemplatePath: 'pages/list',
+      description: 'Successful'
+    }
+  },
+  fn: async function (inputs) {
+    let data = {
+      header: 'Printer List',
+      theads: [
+        'Name',
+        'IP Address',
+        'Model'
+      ],
+      model: 'printer',
+      title: 'All Printers',
+      partialname: false
+    };
+    let partial = path.join(partialPath, `${data.model}.js`);
+    if (fs.existsSync(partial)) {
+      data.partialname = partial;
+    }
+    return data;
+  }
+};

--- a/api/controllers/pages/list/pxemenus.js
+++ b/api/controllers/pages/list/pxemenus.js
@@ -1,0 +1,36 @@
+const fs = require('fs-extra'),
+  path = require('path'),
+  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+module.exports = {
+  friendlyName: 'iPXE Menus',
+  description: 'iPXE/PXE boot menu list page.',
+  inputs: {
+  },
+  exits: {
+    error: {
+      responseType: 'serverError'
+    },
+    success: {
+      viewTemplatePath: 'pages/list',
+      description: 'Successful'
+    }
+  },
+  fn: async function (inputs) {
+    let data = {
+      header: 'iPXE Menu List',
+      theads: [
+        'Name',
+        'Description',
+        'Default'
+      ],
+      model: 'pxemenu',
+      title: 'All iPXE Menus',
+      partialname: false
+    };
+    let partial = path.join(partialPath, `${data.model}.js`);
+    if (fs.existsSync(partial)) {
+      data.partialname = partial;
+    }
+    return data;
+  }
+};

--- a/api/controllers/pages/list/snapins.js
+++ b/api/controllers/pages/list/snapins.js
@@ -1,0 +1,36 @@
+const fs = require('fs-extra'),
+  path = require('path'),
+  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+module.exports = {
+  friendlyName: 'Snapins',
+  description: 'Snapin list page.',
+  inputs: {
+  },
+  exits: {
+    error: {
+      responseType: 'serverError'
+    },
+    success: {
+      viewTemplatePath: 'pages/list',
+      description: 'Successful'
+    }
+  },
+  fn: async function (inputs) {
+    let data = {
+      header: 'Snapin List',
+      theads: [
+        'Name',
+        'File',
+        'Enabled'
+      ],
+      model: 'snapin',
+      title: 'All Snapins',
+      partialname: false
+    };
+    let partial = path.join(partialPath, `${data.model}.js`);
+    if (fs.existsSync(partial)) {
+      data.partialname = partial;
+    }
+    return data;
+  }
+};

--- a/api/controllers/pages/list/storagegroups.js
+++ b/api/controllers/pages/list/storagegroups.js
@@ -1,0 +1,35 @@
+const fs = require('fs-extra'),
+  path = require('path'),
+  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+module.exports = {
+  friendlyName: 'Storage Groups',
+  description: 'Storage Group list page.',
+  inputs: {
+  },
+  exits: {
+    error: {
+      responseType: 'serverError'
+    },
+    success: {
+      viewTemplatePath: 'pages/list',
+      description: 'Successful'
+    }
+  },
+  fn: async function (inputs) {
+    let data = {
+      header: 'Storage Group List',
+      theads: [
+        'Name',
+        'Description'
+      ],
+      model: 'storagegroup',
+      title: 'All Storage Groups',
+      partialname: false
+    };
+    let partial = path.join(partialPath, `${data.model}.js`);
+    if (fs.existsSync(partial)) {
+      data.partialname = partial;
+    }
+    return data;
+  }
+};

--- a/api/controllers/pages/list/storagenodes.js
+++ b/api/controllers/pages/list/storagenodes.js
@@ -1,0 +1,37 @@
+const fs = require('fs-extra'),
+  path = require('path'),
+  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+module.exports = {
+  friendlyName: 'Storage Nodes',
+  description: 'Storage Node list page.',
+  inputs: {
+  },
+  exits: {
+    error: {
+      responseType: 'serverError'
+    },
+    success: {
+      viewTemplatePath: 'pages/list',
+      description: 'Successful'
+    }
+  },
+  fn: async function (inputs) {
+    let data = {
+      header: 'Storage Node List',
+      theads: [
+        'Name',
+        'IP Address',
+        'Master',
+        'Enabled'
+      ],
+      model: 'storagenode',
+      title: 'All Storage Nodes',
+      partialname: false
+    };
+    let partial = path.join(partialPath, `${data.model}.js`);
+    if (fs.existsSync(partial)) {
+      data.partialname = partial;
+    }
+    return data;
+  }
+};

--- a/config/globals.js
+++ b/config/globals.js
@@ -170,24 +170,18 @@ module.exports.globals = {
       ],
     },
     {
-      text: 'Module',
-      plural: 'Modules',
-      link: '/modules',
+      text: 'Snapin',
+      plural: 'Snapins',
+      link: '/snapins',
       icon: 'fa-cogs',
-      subLinks: [
-        {
-          link: '/modules/create',
-          text: 'Create New Module'
-        },
-        {
-          link: '/modules/export',
-          text: 'Export Modules'
-        },
-        {
-          link: '/modules/import',
-          text: 'Import Modules'
-        }
-      ],
+      subLinks: false
+    },
+    {
+      text: 'Printer',
+      plural: 'Printers',
+      link: '/printers',
+      icon: 'fa-print',
+      subLinks: false
     },
     {
       text: 'Task',
@@ -276,22 +270,9 @@ module.exports.globals = {
     {
       text: 'iPXE Menu',
       plural: 'iPXE Menus',
-      link: '/ipxes',
+      link: '/pxemenus',
       icon: 'fa-bars',
-      subLinks: [
-        {
-          link: '/ipxes/create',
-          text: 'Create New iPXE Menu'
-        },
-        {
-          link: '/ipxes/export',
-          text: 'Export iPXE Menus'
-        },
-        {
-          link: '/ipxes/import',
-          text: 'Import iPXE Menus'
-        }
-      ],
+      subLinks: false
     },
   ],
   authenticationMechanisms: [

--- a/config/routes.js
+++ b/config/routes.js
@@ -87,6 +87,21 @@ module.exports.routes = {
   'GET /images/create':                      {action: 'pages/create/images'},
   'POST /images/create':                     {action: 'general/create'},
 
+  // Storage Group Views
+  'GET /storagegroups':                      {action: 'pages/list/storagegroups'},
+
+  // Storage Node Views
+  'GET /storagenodes':                       {action: 'pages/list/storagenodes'},
+
+  // Snapin Views
+  'GET /snapins':                            {action: 'pages/list/snapins'},
+
+  // Printer Views
+  'GET /printers':                           {action: 'pages/list/printers'},
+
+  // iPXE Menu Views
+  'GET /pxemenus':                           {action: 'pages/list/pxemenus'},
+
   // Role Views
   'GET /roles':                              {action: 'pages/list/roles'},
 

--- a/views/pages/login.ejs
+++ b/views/pages/login.ejs
@@ -5,6 +5,9 @@
   <div class="card">
     <div class="card-body login-card-body">
       <p class="login-box-msg">Sign in to start your session</p>
+      <% if (typeof req !== 'undefined' && req.query && req.query.failed) { %>
+      <div class="alert alert-danger">Invalid username or password.</div>
+      <% } %>
       <form action="/login" method="post">
         <div class="input-group mb-3">
           <input name="username" type="text" class="form-control" placeholder="Username">

--- a/views/pages/partials/list/printer.js
+++ b/views/pages/partials/list/printer.js
@@ -1,0 +1,19 @@
+(function($) {
+  let path = $(location).attr('pathname').replace(/s$/,'');
+  $('#listtable').registerTable(undefined, {
+    order: [
+      [0, 'asc']
+    ],
+    columns: [
+      {data: 'name'},
+      {data: 'ip'},
+      {data: 'printerModel'}
+    ],
+    rowId: 'id',
+    serverSide: true,
+    ajax: {
+      type: 'post',
+      url: `/api/v1${path}/datatable`
+    }
+  });
+})(jQuery);

--- a/views/pages/partials/list/pxemenu.js
+++ b/views/pages/partials/list/pxemenu.js
@@ -1,0 +1,19 @@
+(function($) {
+  let path = $(location).attr('pathname').replace(/s$/,'');
+  $('#listtable').registerTable(undefined, {
+    order: [
+      [0, 'asc']
+    ],
+    columns: [
+      {data: 'name'},
+      {data: 'description'},
+      {data: 'default'}
+    ],
+    rowId: 'id',
+    serverSide: true,
+    ajax: {
+      type: 'post',
+      url: `/api/v1${path}/datatable`
+    }
+  });
+})(jQuery);

--- a/views/pages/partials/list/snapin.js
+++ b/views/pages/partials/list/snapin.js
@@ -1,0 +1,19 @@
+(function($) {
+  let path = $(location).attr('pathname').replace(/s$/,'');
+  $('#listtable').registerTable(undefined, {
+    order: [
+      [0, 'asc']
+    ],
+    columns: [
+      {data: 'name'},
+      {data: 'file'},
+      {data: 'isEnabled'}
+    ],
+    rowId: 'id',
+    serverSide: true,
+    ajax: {
+      type: 'post',
+      url: `/api/v1${path}/datatable`
+    }
+  });
+})(jQuery);

--- a/views/pages/partials/list/storagegroup.js
+++ b/views/pages/partials/list/storagegroup.js
@@ -1,0 +1,18 @@
+(function($) {
+  let path = $(location).attr('pathname').replace(/s$/,'');
+  $('#listtable').registerTable(undefined, {
+    order: [
+      [0, 'asc']
+    ],
+    columns: [
+      {data: 'name'},
+      {data: 'description'}
+    ],
+    rowId: 'id',
+    serverSide: true,
+    ajax: {
+      type: 'post',
+      url: `/api/v1${path}/datatable`
+    }
+  });
+})(jQuery);

--- a/views/pages/partials/list/storagenode.js
+++ b/views/pages/partials/list/storagenode.js
@@ -1,0 +1,20 @@
+(function($) {
+  let path = $(location).attr('pathname').replace(/s$/,'');
+  $('#listtable').registerTable(undefined, {
+    order: [
+      [0, 'asc']
+    ],
+    columns: [
+      {data: 'name'},
+      {data: 'ip'},
+      {data: 'isMaster'},
+      {data: 'isEnabled'}
+    ],
+    rowId: 'id',
+    serverSide: true,
+    ajax: {
+      type: 'post',
+      url: `/api/v1${path}/datatable`
+    }
+  });
+})(jQuery);


### PR DESCRIPTION
## Login error handling (fix)
A wrong username/password returned a **500** ("Failed to serialize user into session") because the controller called `req.login(undefined)`. Now bad credentials return **401 + message** (JSON/API) or redirect the form to `/login?failed=1` with a visible "Invalid username or password" alert.

## Sidebar list pages (feature)
Navigable list pages (route + page controller + DataTables partial) for the entities added earlier this cycle:
- Storage Groups, Storage Nodes, Snapins, Printers, iPXE menus

Sidebar updated: "Module" → Snapin (`/snapins`), new Printers entry, "iPXE Menu" → `/pxemenus`. Simple links to working list pages (create/export/import sublinks deferred).

## Verified
- Bad login: 401 (JSON) / 302 → `/login?failed=1` with alert (browser); good login still works
- All five new pages render 200 under auth; their `/api/v1/<model>/datatable` endpoints respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)