### PR TITLE
feat(web): working create forms + fix create save flow

### DIFF
--- a/api/controllers/general/save.js
+++ b/api/controllers/general/save.js
@@ -1,0 +1,45 @@
+module.exports = {
+  friendlyName: 'Save',
+  description: 'Handle a server-rendered create form POST (e.g. POST /groups/create).',
+  exits: {
+    success: {
+      description: 'Record created; redirected to the list.'
+    },
+    error: {
+      responseType: 'serverError'
+    }
+  },
+  fn: async function () {
+    let req = this.req,
+      res = this.res,
+      // Derive the model from the URL, e.g. /groups/create -> group
+      segments = req.path.split('/').filter(Boolean),
+      plural = segments[0],
+      model = plural.replace(/s$/, '');
+
+    if (!model || !sails.models[model]) {
+      res.notFound();
+      return res.end();
+    }
+
+    // Permission: the generic `create` policy can't run here (no :model param),
+    // so check the create permission for the derived model directly.
+    if (!_.get(req, 'user.permissions.stock.' + model + '.create')) {
+      res.forbidden();
+      return res.end();
+    }
+
+    // Build the values from the body, dropping non-attribute keys.
+    let values = _.omit(req.allParams(), ['model', '_csrf']);
+
+    try {
+      await sails.models[model].create(values)
+        .intercept('E_UNIQUE', () => 'unique')
+        .intercept({ name: 'UsageError' }, () => 'usage');
+    } catch (unused) {
+      return res.redirect(`/${plural}/create?failed=1`);
+    }
+
+    return res.redirect(`/${plural}`);
+  }
+};

--- a/api/controllers/pages/create/printers.js
+++ b/api/controllers/pages/create/printers.js
@@ -1,0 +1,55 @@
+const fs = require('fs-extra'),
+  path = require('path'),
+  partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
+module.exports = {
+  friendlyName: 'View printers create',
+  description: 'Display "Printer create" page.',
+  exits: {
+    success: {
+      viewTemplatePath: 'pages/create'
+    }
+  },
+  fn: async function () {
+    let data = {
+      model: 'printer',
+      header: 'Create New Printer',
+      formItems: {
+        name: {
+          textarea: false, text: 'Name', type: 'text', id: 'prname', classes: [], placeholder: 'FrontDesk'
+        },
+        description: {
+          textarea: true, text: 'Description', type: 'text', id: 'prdescription', classes: [], placeholder: 'Some general description'
+        },
+        printerModel: {
+          textarea: false, text: 'Model', type: 'text', id: 'prmodel', classes: [], placeholder: 'HP LaserJet'
+        },
+        port: {
+          textarea: false, text: 'Port', type: 'text', id: 'prport', classes: [], placeholder: 'LPT1'
+        },
+        ip: {
+          textarea: false, text: 'IP Address', type: 'text', id: 'prip', classes: [], placeholder: '10.0.0.20'
+        }
+      },
+      formButtons: {
+        Cancel: { classes: ['btn-warning','float-start'], type: 'submit' },
+        Create: { classes: ['btn-success','float-end'], type: 'submit' }
+      },
+      partialname: false
+    };
+    data.title = 'Create New Printer';
+    data.form = await sails.helpers.formGenerator.with({
+      model: data.model,
+      method: 'post',
+      action: `/${data.model}s/create`,
+      id: `${data.model}-create`,
+      classes: [`${data.model}-create-form`],
+      formItems: data.formItems,
+      formButtons: data.formButtons
+    });
+    let partial = path.join(partialPath, `${data.model}.js`);
+    if (fs.existsSync(partial)) {
+      data.partialname = partial;
+    }
+    return data;
+  }
+};

--- a/api/controllers/pages/create/pxemenus.js
+++ b/api/controllers/pages/create/pxemenus.js
@@ -1,0 +1,52 @@
+const fs = require('fs-extra'),
+  path = require('path'),
+  partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
+module.exports = {
+  friendlyName: 'View iPXE menus create',
+  description: 'Display "iPXE Menu create" page.',
+  exits: {
+    success: {
+      viewTemplatePath: 'pages/create'
+    }
+  },
+  fn: async function () {
+    let data = {
+      model: 'pxemenu',
+      header: 'Create New iPXE Menu',
+      formItems: {
+        name: {
+          textarea: false, text: 'Name', type: 'text', id: 'pxname', classes: [], placeholder: 'fog.local'
+        },
+        description: {
+          textarea: true, text: 'Description', type: 'text', id: 'pxdescription', classes: [], placeholder: 'Boot to FOG'
+        },
+        params: {
+          textarea: true, text: 'Parameters', type: 'text', id: 'pxparams', classes: [], placeholder: 'kernel ...'
+        },
+        default: {
+          textarea: false, text: 'Default Entry', type: 'checkbox', id: 'pxdefault', classes: [], checked: false
+        }
+      },
+      formButtons: {
+        Cancel: { classes: ['btn-warning','float-start'], type: 'submit' },
+        Create: { classes: ['btn-success','float-end'], type: 'submit' }
+      },
+      partialname: false
+    };
+    data.title = 'Create New iPXE Menu';
+    data.form = await sails.helpers.formGenerator.with({
+      model: data.model,
+      method: 'post',
+      action: `/${data.model}s/create`,
+      id: `${data.model}-create`,
+      classes: [`${data.model}-create-form`],
+      formItems: data.formItems,
+      formButtons: data.formButtons
+    });
+    let partial = path.join(partialPath, `${data.model}.js`);
+    if (fs.existsSync(partial)) {
+      data.partialname = partial;
+    }
+    return data;
+  }
+};

--- a/api/controllers/pages/create/snapins.js
+++ b/api/controllers/pages/create/snapins.js
@@ -1,0 +1,55 @@
+const fs = require('fs-extra'),
+  path = require('path'),
+  partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
+module.exports = {
+  friendlyName: 'View snapins create',
+  description: 'Display "Snapin create" page.',
+  exits: {
+    success: {
+      viewTemplatePath: 'pages/create'
+    }
+  },
+  fn: async function () {
+    let data = {
+      model: 'snapin',
+      header: 'Create New Snapin',
+      formItems: {
+        name: {
+          textarea: false, text: 'Name', type: 'text', id: 'spname', classes: [], placeholder: '7-Zip'
+        },
+        description: {
+          textarea: true, text: 'Description', type: 'text', id: 'spdescription', classes: [], placeholder: 'Some general description'
+        },
+        file: {
+          textarea: false, text: 'File', type: 'text', id: 'spfile', classes: [], placeholder: '7z.exe'
+        },
+        args: {
+          textarea: false, text: 'Arguments', type: 'text', id: 'spargs', classes: [], placeholder: '/S'
+        },
+        reboot: {
+          textarea: false, text: 'Reboot After', type: 'checkbox', id: 'spreboot', classes: [], checked: false
+        }
+      },
+      formButtons: {
+        Cancel: { classes: ['btn-warning','float-start'], type: 'submit' },
+        Create: { classes: ['btn-success','float-end'], type: 'submit' }
+      },
+      partialname: false
+    };
+    data.title = 'Create New Snapin';
+    data.form = await sails.helpers.formGenerator.with({
+      model: data.model,
+      method: 'post',
+      action: `/${data.model}s/create`,
+      id: `${data.model}-create`,
+      classes: [`${data.model}-create-form`],
+      formItems: data.formItems,
+      formButtons: data.formButtons
+    });
+    let partial = path.join(partialPath, `${data.model}.js`);
+    if (fs.existsSync(partial)) {
+      data.partialname = partial;
+    }
+    return data;
+  }
+};

--- a/api/controllers/pages/create/storagegroups.js
+++ b/api/controllers/pages/create/storagegroups.js
@@ -1,0 +1,62 @@
+const fs = require('fs-extra'),
+  path = require('path'),
+  partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
+module.exports = {
+  friendlyName: 'View storage groups create',
+  description: 'Display "Storage Group create" page.',
+  exits: {
+    success: {
+      viewTemplatePath: 'pages/create'
+    }
+  },
+  fn: async function () {
+    let data = {
+      model: 'storagegroup',
+      header: 'Create New Storage Group',
+      formItems: {
+        name: {
+          textarea: false,
+          text: 'Name',
+          type: 'text',
+          id: 'sgname',
+          classes: [],
+          placeholder: 'Default'
+        },
+        description: {
+          textarea: true,
+          text: 'Description',
+          type: 'text',
+          id: 'sgdescription',
+          classes: [],
+          placeholder: 'Some general description'
+        }
+      },
+      formButtons: {
+        Cancel: {
+          classes: ['btn-warning','float-start'],
+          type: 'submit'
+        },
+        Create: {
+          classes: ['btn-success','float-end'],
+          type: 'submit'
+        }
+      },
+      partialname: false
+    };
+    data.title = 'Create New Storage Group';
+    data.form = await sails.helpers.formGenerator.with({
+      model: data.model,
+      method: 'post',
+      action: `/${data.model}s/create`,
+      id: `${data.model}-create`,
+      classes: [`${data.model}-create-form`],
+      formItems: data.formItems,
+      formButtons: data.formButtons
+    });
+    let partial = path.join(partialPath, `${data.model}.js`);
+    if (fs.existsSync(partial)) {
+      data.partialname = partial;
+    }
+    return data;
+  }
+};

--- a/api/controllers/pages/create/storagenodes.js
+++ b/api/controllers/pages/create/storagenodes.js
@@ -1,0 +1,61 @@
+const fs = require('fs-extra'),
+  path = require('path'),
+  partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
+module.exports = {
+  friendlyName: 'View storage nodes create',
+  description: 'Display "Storage Node create" page.',
+  exits: {
+    success: {
+      viewTemplatePath: 'pages/create'
+    }
+  },
+  fn: async function () {
+    let data = {
+      model: 'storagenode',
+      header: 'Create New Storage Node',
+      formItems: {
+        name: {
+          textarea: false, text: 'Name', type: 'text', id: 'snname', classes: [], placeholder: 'DefaultMember'
+        },
+        ip: {
+          textarea: false, text: 'IP Address', type: 'text', id: 'snip', classes: [], placeholder: '10.0.0.10'
+        },
+        path: {
+          textarea: false, text: 'Image Path', type: 'text', id: 'snpath', classes: [], placeholder: '/images/'
+        },
+        ftppath: {
+          textarea: false, text: 'FTP Path', type: 'text', id: 'snftppath', classes: [], placeholder: '/images/'
+        },
+        user: {
+          textarea: false, text: 'Management Username', type: 'text', id: 'snuser', classes: [], placeholder: 'fogproject'
+        },
+        pass: {
+          textarea: false, text: 'Management Password', type: 'password', id: 'snpass', classes: [], placeholder: ''
+        },
+        isMaster: {
+          textarea: false, text: 'Is Master Node', type: 'checkbox', id: 'snmaster', classes: [], checked: false
+        }
+      },
+      formButtons: {
+        Cancel: { classes: ['btn-warning','float-start'], type: 'submit' },
+        Create: { classes: ['btn-success','float-end'], type: 'submit' }
+      },
+      partialname: false
+    };
+    data.title = 'Create New Storage Node';
+    data.form = await sails.helpers.formGenerator.with({
+      model: data.model,
+      method: 'post',
+      action: `/${data.model}s/create`,
+      id: `${data.model}-create`,
+      classes: [`${data.model}-create-form`],
+      formItems: data.formItems,
+      formButtons: data.formButtons
+    });
+    let partial = path.join(partialPath, `${data.model}.js`);
+    if (fs.existsSync(partial)) {
+      data.partialname = partial;
+    }
+    return data;
+  }
+};

--- a/api/helpers/form-generator.js
+++ b/api/helpers/form-generator.js
@@ -137,7 +137,7 @@ module.exports = {
       switch (input.textarea) {
         case true:
           form += `
-            <div class="form-group row">
+            <div class="row mb-3">
               <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
               <div class="col-sm-10">
                 <textarea${iId} class="form-control${iClass}"${iPlaceholder}${iName}>${iValue}</textarea>
@@ -152,12 +152,11 @@ module.exports = {
                 iChecked = ` checked`;
               }
               form += `
-                <div class="form-group row">
+                <div class="row mb-3">
                   <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
                   <div class="col-sm-10">
-                    <div class="icheck-primary d-inline">
-                      <input type="checkbox" class="${iClass}"${iId}${iName}${iChecked}/>
-                      <label${iFor}></label>
+                    <div class="form-check mt-2">
+                      <input type="checkbox" class="form-check-input${iClass}"${iId}${iName}${iChecked}/>
                     </div>
                   </div>
                 </div>
@@ -169,13 +168,13 @@ module.exports = {
                 iChecked=` selected`;
               }
               form += `
-                <div class="form-group row">
+                <div class="row mb-3">
                 </div>
               `
               break;
             default:
               form += `
-                <div class="form-group row">
+                <div class="row mb-3">
                   <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
                   <div class="col-sm-10">
                     <input type="${input.type}"${iId} class="form-control${iClass}"${iName}${iPlaceholder} value="${iValue}"${iMaxlength}${iMinlength}${iRegex}${iChecked}/>

--- a/config/globals.js
+++ b/config/globals.js
@@ -174,14 +174,24 @@ module.exports.globals = {
       plural: 'Snapins',
       link: '/snapins',
       icon: 'fa-cogs',
-      subLinks: false
+      subLinks: [
+        {
+          link: '/snapins/create',
+          text: 'Create New Snapin'
+        }
+      ]
     },
     {
       text: 'Printer',
       plural: 'Printers',
       link: '/printers',
       icon: 'fa-print',
-      subLinks: false
+      subLinks: [
+        {
+          link: '/printers/create',
+          text: 'Create New Printer'
+        }
+      ]
     },
     {
       text: 'Task',
@@ -272,7 +282,12 @@ module.exports.globals = {
       plural: 'iPXE Menus',
       link: '/pxemenus',
       icon: 'fa-bars',
-      subLinks: false
+      subLinks: [
+        {
+          link: '/pxemenus/create',
+          text: 'Create New iPXE Menu'
+        }
+      ]
     },
   ],
   authenticationMechanisms: [

--- a/config/policies.js
+++ b/config/policies.js
@@ -19,6 +19,8 @@ module.exports.policies = {
   'general/destroy':       ['isLoggedIn','isAuthenticated','destroy'],
   'general/datatable':     ['isLoggedIn','isAuthenticated','read'],
   'general/columns':       ['isLoggedIn','isAuthenticated','read'],
+  // save derives the model from the URL and checks create permission itself
+  'general/save':          ['isLoggedIn','isAuthenticated'],
 
 
   // Group Policies

--- a/config/routes.js
+++ b/config/routes.js
@@ -75,32 +75,42 @@ module.exports.routes = {
   // Group Views
   'GET /groups':                             {action: 'pages/list/groups'},
   'GET /groups/create':                      {action: 'pages/create/groups'},
-  'POST /groups/create':                     {action: 'general/create'},
+  'POST /groups/create':                     {action: 'general/save'},
 
   // Host Views
   'GET /hosts':                              {action: 'pages/list/hosts'},
   'GET /hosts/create':                       {action: 'pages/create/hosts'},
-  'POST /hosts/create':                      {action: 'general/create'},
+  'POST /hosts/create':                      {action: 'general/save'},
 
   // Image Views
   'GET /images':                             {action: 'pages/list/images'},
   'GET /images/create':                      {action: 'pages/create/images'},
-  'POST /images/create':                     {action: 'general/create'},
+  'POST /images/create':                     {action: 'general/save'},
 
   // Storage Group Views
   'GET /storagegroups':                      {action: 'pages/list/storagegroups'},
+  'GET /storagegroups/create':               {action: 'pages/create/storagegroups'},
+  'POST /storagegroups/create':              {action: 'general/save'},
 
   // Storage Node Views
   'GET /storagenodes':                       {action: 'pages/list/storagenodes'},
+  'GET /storagenodes/create':                {action: 'pages/create/storagenodes'},
+  'POST /storagenodes/create':               {action: 'general/save'},
 
   // Snapin Views
   'GET /snapins':                            {action: 'pages/list/snapins'},
+  'GET /snapins/create':                     {action: 'pages/create/snapins'},
+  'POST /snapins/create':                    {action: 'general/save'},
 
   // Printer Views
   'GET /printers':                           {action: 'pages/list/printers'},
+  'GET /printers/create':                    {action: 'pages/create/printers'},
+  'POST /printers/create':                   {action: 'general/save'},
 
   // iPXE Menu Views
   'GET /pxemenus':                           {action: 'pages/list/pxemenus'},
+  'GET /pxemenus/create':                    {action: 'pages/create/pxemenus'},
+  'POST /pxemenus/create':                   {action: 'general/save'},
 
   // Role Views
   'GET /roles':                              {action: 'pages/list/roles'},
@@ -111,7 +121,7 @@ module.exports.routes = {
   // User Views
   'GET /users':                              {action: 'pages/list/users'},
   'GET /users/create':                       {action: 'pages/create/users'},
-  'POST /users/create':                      {action: 'general/create'},
+  'POST /users/create':                      {action: 'general/save'},
   'GET /user/me':                            {action: 'user/listme'},
 
   // Workflow Views


### PR DESCRIPTION
## Problem
Create forms POST to a literal `/<plural>/create` route wired to `general/create`, which reads the model from a `:model` route param that isn't present there — so **every create returned 403** (and would have crashed past the policy).

## Fix
- **`general/save`**: derives the model from the URL (`/groups/create` → `group`), checks that model's `create` permission, creates the record, and redirects to the list — or back to `/<plural>/create?failed=1` on a validation/unique error. All `POST /<plural>/create` routes repointed to it.
- **Create pages** for the new entities (Storage Group/Node, Snapin, Printer, iPXE menu) + `GET`/`POST` routes + "Create New" sidebar sublinks.
- **`form-generator`** → Bootstrap 5: `.form-group row` → `.row mb-3`, icheck checkbox → `.form-check`, buttons `float-start`/`float-end`.

## Verified (live)
All create pages render; form POST creates + redirects to the list; required-field validation bounces back without creating; records persist (confirmed directly in Mongo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)