### PR TITLE
fix(auth): permissions for session-authenticated (browser) requests

### DIFF
--- a/config/passport/jwt.js
+++ b/config/passport/jwt.js
@@ -13,7 +13,11 @@ passport.serializeUser(async (user, done) => {
 passport.deserializeUser(async (id, done) => {
   await User.findOne({id}).populateAll().exec(async (err, user) => {
     if (err) return done(err);
-    done(null, user);
+    // toJSON() runs the User model's customToJSON, which computes `permissions`
+    // from the user's roles. Without it, session-authenticated requests (browser
+    // login without "Remember Me") get a req.user with no permissions, so every
+    // permission-checked action (create, list datatable, ...) 403s.
+    done(null, user ? user.toJSON() : false);
   });
 });
 passport.use(new JWTStrategy(opts,

--- a/config/passport/local.js
+++ b/config/passport/local.js
@@ -7,7 +7,9 @@ passport.serializeUser(async (user, done) => {
 passport.deserializeUser(async (id, done) => {
   await User.findOne({id}).populateAll().exec(async (err, user) => {
     if (err) return done(err);
-    done(null, user);
+    // See config/passport/jwt.js: toJSON() computes `permissions` from roles so
+    // session-authenticated requests have them (otherwise permission checks 403).
+    done(null, user ? user.toJSON() : false);
   });
 });
 passport.use(new LocalStrategy(


### PR DESCRIPTION
## Problem
Logging in via the browser **without "Remember Me"** authenticates via the passport session (no JWT cookie). In that path `req.user` came from `deserializeUser` as a **raw record with no `permissions`**, so every permission-checked action returned **403** — both create forms and list datatables were Forbidden for browser users. (The JWT/API path was unaffected because it runs `user.toJSON()`.)

## Fix
`deserializeUser` now returns `user.toJSON()`, which runs the `User` model's `customToJSON` to compute `permissions` from roles — matching the JWT path. Applied in both `config/passport/jwt.js` and `config/passport/local.js`.

## Verified
Session-only login can now create (302 → list) and read the datatable (200); JWT / remember-me path still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)