### PR TITLE
fix(web): dashboard data + charts (disk usage, activity)

### DIFF
--- a/api/controllers/pages/dashboard.js
+++ b/api/controllers/pages/dashboard.js
@@ -4,7 +4,6 @@ const fs = require('fs-extra'),
   partialPath = path.join(appRoot, 'views', 'pages', 'partials'),
   imagePath = `${path.parse(appRoot).root}images`,
   si = require('systeminformation'),
-  os = require('os'),
   moment = require('moment'),
   checkDiskSpace = require('check-disk-space').default;
 module.exports = {
@@ -15,75 +14,60 @@ module.exports = {
       viewTemplatePath: 'pages/dashboard'
     }
   },
-  fn: async function (inputs, exits) {
-    let free = 0,
-      size = 0,
-      used = 0,
+  fn: async function () {
+    let webserver = 'Unknown',
       defaultInet = await si.networkInterfaceDefault(),
       interfaces = await si.networkInterfaces(),
-      webserver = false,
-      uptime = await si.time().uptime * 1000,
-      loadaverage = await si.currentLoad(),
-      legend = [],
-      staged=3,
-      active=6,
-      avail=(10 - (staged + active));
+      timeInfo = await si.time(),
+      uptime = moment.duration((timeInfo.uptime || 0) * 1000).humanize(),
+      load = await si.currentLoad(),
+      loadaverage = 'N/A';
 
-    loadaverage = loadaverage.avgload;
-    uptime = moment.duration(uptime);
-    uptime = uptime.humanize();
-
-    interfaces.forEach((inet) => {
-      if (defaultInet !== inet.ifaceName) {
-        return;
+    // systeminformation v5: currentLoad() -> avgLoad / currentLoad (camelCase)
+    if (load) {
+      if (typeof load.avgLoad === 'number') {
+        loadaverage = load.avgLoad;
+      } else if (typeof load.currentLoad === 'number') {
+        loadaverage = `${load.currentLoad.toFixed(2)}%`;
       }
-      webserver = inet.ip4;
+    }
+
+    // systeminformation v5: networkInterfaces() entries use `iface`
+    (Array.isArray(interfaces) ? interfaces : [interfaces]).forEach((inet) => {
+      if (inet && inet.iface === defaultInet) {
+        webserver = inet.ip4;
+      }
     });
 
-    checkDiskSpace(imagePath).then(async (diskSpace) => {
-      size = diskSpace.size;
-      free = diskSpace.free;
-      used = size - free;
-      legend = [
-        {
-          name: 'Free: ' + await sails.helpers.readableBytes(free),
-          color: 'success'
-        },
-        {
-          name: 'Used: ' + await sails.helpers.readableBytes(used),
-          color: 'danger'
-        }
-      ];
-      partial = path.join(partialPath, `${data.model}.js`);
-      if (fs.existsSync(partial)) {
-        data.partialname = partial;
-      }
-      return exits.success({
-        header: 'Dashboard',
-        title: 'Dashboard',
-        model: 'dashboard',
-        partialname: partial,
-        free,
-        used,
-        size,
-        legend,
-        webserver,
-        loadaverage,
-        uptime,
-        avail: avail,
-        staged: staged,
-        active: active
-      });
-    });
-    // Respond with view.
+    // Disk usage of the image store. Fall back to the filesystem root when the
+    // image path does not exist (e.g. in development).
+    let free = 0, size = 0, used = 0;
+    try {
+      let diskSpace = await checkDiskSpace(imagePath);
+      size = diskSpace.size; free = diskSpace.free; used = size - free;
+    } catch (unused) {
+      try {
+        let diskSpace = await checkDiskSpace(path.parse(appRoot).root);
+        size = diskSpace.size; free = diskSpace.free; used = size - free;
+      } catch (unused2) { /* leave zeros */ }
+    }
+
+    let legend = [
+      { name: 'Free: ' + await sails.helpers.readableBytes(free), color: 'success' },
+      { name: 'Used: ' + await sails.helpers.readableBytes(used), color: 'danger' }
+    ];
+
+    // Activity placeholders until real task data is wired up.
+    let staged = 3, active = 6, avail = 10 - (staged + active);
+
     let data = {
+      header: 'Dashboard',
       title: 'Dashboard',
       model: 'dashboard',
       partialname: false,
-      legend: legend,
-      free: free,
-      used: used,
-      size: size
+      free, used, size, legend,
+      webserver, loadaverage, uptime,
+      avail, staged, active
     };
     let partial = path.join(partialPath, `${data.model}.js`);
     if (fs.existsSync(partial)) {

--- a/api/helpers/readable-bytes.js
+++ b/api/helpers/readable-bytes.js
@@ -17,8 +17,11 @@ module.exports = {
     },
   },
   fn: async function (inputs) {
-    let bytes = inputs.bytes,
-      i = Math.floor(Math.log(bytes) / Math.log(1024));
+    let bytes = inputs.bytes;
+    if (!bytes || bytes <= 0 || !isFinite(bytes)) {
+      return `0 ${sizes[0]}`;
+    }
+    let i = Math.floor(Math.log(bytes) / Math.log(1024));
     return `${(bytes / Math.pow(1024, i)).toFixed(2) * 1} ${sizes[i]}`;
   }
 };

--- a/tasks/config/copy.js
+++ b/tasks/config/copy.js
@@ -48,17 +48,9 @@ module.exports = function(grunt) {
         },
         {
           expand: true,
-          cwd: './node_modules/admin-lte/node_modules/chart.js/dist/',
+          cwd: './node_modules/chart.js/dist/',
           src: [
-            'Chart.bundle.min.js'
-          ],
-          dest: '.tmp/public/js'
-        },
-        {
-          expand: true,
-          cwd: './node_modules/chartjs-plugin-labels/src/',
-          src: [
-            'chartjs-plugin-labels.js'
+            'chart.umd.min.js*'
           ],
           dest: '.tmp/public/js'
         },

--- a/views/pages/partials/dashboard.js
+++ b/views/pages/partials/dashboard.js
@@ -1,183 +1,95 @@
 (function($) {
-  let free = $('#free').val(),
-    used = $('#used').val(),
-    hFree = $.readableBytes(free),
-    hUsed = $.readableBytes(used),
-    qavail = $('#avail').val(),
-    qstaged = $('#staged').val(),
-    qactive = $('#active').val();
-  // Activity Usage
-  let activeUsageCanvas = $('#activityUsage').get(0).getContext('2d'),
-    activeUsageData = {
-      labels: [
-        `Available: ${qavail}`,
-        `Active: ${qactive}`,
-        `Staged: ${qstaged}`
-      ],
-      datasets: [
-        {
-          data: [
-            qavail,
-            qactive,
-            qstaged
-          ],
-          backgroundColor: [
-            '#28a745',
-            '#dc3545',
-            '#007bff'
-          ]
-        }
-      ]
-    },
-    activeUsageOpts = {
-      responsive: true,
-      plugins: {
-        labels: {
-          reder: 'percentage',
-          precision: 0,
-          fontColor: '#ffffff',
-          fontSize: 12
-        }
-      },
-      legend: {
-        position: 'bottom'
-      },
-      tooltips: {
-        callbacks: {
-          label: function(tooltipItem, data) {
-            var dataset = data.datasets[tooltipItem.datasetIndex];
-            var meta = dataset._meta[Object.keys(dataset._meta)[0]];
-            var total = meta.total;
-            var currentValue = dataset.data[tooltipItem.index];
-            var percentage = parseFloat((currentValue/total*100).toFixed(1));
-            var hText = $.readableBytes(currentValue);
-            return `${hText} (${percentage}%)`;
-          },
-        }
-      }
-    },
-    activeUsageChart = new Chart(activeUsageCanvas, {
-      type: 'doughnut',
-      data: activeUsageData,
-      options: activeUsageOpts
-    });
-  // Disk Usage
-  let diskUsageCanvas = $('#diskUsage').get(0).getContext('2d'),
-    diskUsageData = {
-      labels: [
-        `Free: ${hFree}`,
-        `Used: ${hUsed}`
-      ],
-      datasets: [
-        {
-          data: [
-            free,
-            used
-          ],
-          backgroundColor: [
-            '#28a745',
-            '#dc3545',
-            '#007bff'
-          ]
-        }
-      ]
-    },
-    diskUsageOpts = {
-      responsive: true,
-      plugins: {
-        labels: {
-          render: 'percentage',
-          precision: 0,
-          fontColor: '#ffffff',
-          fontSize: 12
-        }
-      },
-      legend: {
-        position: 'bottom'
-      },
-      tooltips: {
-        callbacks: {
-          label: function(tooltipItem, data) {
-            var dataset = data.datasets[tooltipItem.datasetIndex];
-            var meta = dataset._meta[Object.keys(dataset._meta)[0]];
-            var total = meta.total;
-            var currentValue = dataset.data[tooltipItem.index];
-            var percentage = parseFloat((currentValue/total*100).toFixed(1));
-            var hText = $.readableBytes(currentValue);
-            return `${hText} (${percentage}%)`;
-          },
-        }
-      }
-    },
-    diskUsageChart = new Chart(diskUsageCanvas, {
-      type: 'doughnut',
-      data: diskUsageData,
-      options: diskUsageOpts
-    });
-  // Task History
-  let taskHistoryChart = undefined,
-    taskHistoryTimeout,
-    tInterval = 30;
-
-  function getTInterval() {
-    let val = $('.taskDayFilters.active').attr('length');
-
-    switch (val) {
-      case '-1':
-        updateHistory(365);
-        break;
-      case '2':
-        updateHistory(60);
-        break;
-      case '3':
-        updateHistory(90);
-        break;
-      case '6':
-        updateHistory(183);
-        break;
-      default:
-        updateHistory(30);
-    }
-
-    taskHistoryTimeout = setTimeout(getTInterval, 3000);
+  // Percentage helper for doughnut tooltips (Chart.js v4).
+  function pctLabel(context) {
+    let val = Number(context.parsed) || 0,
+      total = context.dataset.data.reduce((a, b) => a + Number(b), 0),
+      pct = total ? (val / total * 100).toFixed(1) : 0;
+    return ` ${context.label}: ${pct}%`;
   }
 
-  function historyCanvas() {
-    // Call a function to redraw other content (texts, images, etc)
-    if (typeof taskHistoryChart === 'undefined') {
-      var history = $('#taskHistory');
-      var htx = history.get(0).getContext('2d');
-      var htxOpts = {
+  // Activity Usage
+  let qavail = Number($('#avail').val()) || 0,
+    qactive = Number($('#active').val()) || 0,
+    qstaged = Number($('#staged').val()) || 0,
+    activeUsageCanvas = $('#activityUsage').get(0);
+  if (activeUsageCanvas) {
+    new Chart(activeUsageCanvas.getContext('2d'), {
+      type: 'doughnut',
+      data: {
+        labels: [
+          `Available: ${qavail}`,
+          `Active: ${qactive}`,
+          `Staged: ${qstaged}`
+        ],
+        datasets: [{
+          data: [qavail, qactive, qstaged],
+          backgroundColor: ['#28a745', '#dc3545', '#007bff']
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { position: 'bottom' },
+          tooltip: { callbacks: { label: pctLabel } }
+        }
+      }
+    });
+  }
+
+  // Disk Usage
+  let free = Number($('#free').val()) || 0,
+    used = Number($('#used').val()) || 0,
+    hFree = $.readableBytes(free),
+    hUsed = $.readableBytes(used),
+    total = free + used,
+    freePct = total ? (free / total * 100).toFixed(1) : 0,
+    usedPct = total ? (used / total * 100).toFixed(1) : 0,
+    diskUsageCanvas = $('#diskUsage').get(0);
+  if (diskUsageCanvas) {
+    new Chart(diskUsageCanvas.getContext('2d'), {
+      type: 'doughnut',
+      data: {
+        labels: [
+          `Free: ${hFree} (${freePct}%)`,
+          `Used: ${hUsed} (${usedPct}%)`
+        ],
+        datasets: [{
+          data: [free, used],
+          backgroundColor: ['#28a745', '#dc3545']
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { position: 'bottom' },
+          tooltip: { callbacks: { label: pctLabel } }
+        }
+      }
+    });
+  }
+
+  // Task History (category x-axis -> no time adapter needed)
+  let taskHistoryChart,
+    taskHistoryTimeout;
+
+  function historyCanvas(taskChartData) {
+    let history = $('#taskHistory').get(0);
+    if (!history) return;
+    if (!taskHistoryChart) {
+      taskHistoryChart = new Chart(history.getContext('2d'), {
         type: 'line',
         data: taskChartData,
         options: {
           responsive: true,
-          scales: {
-            xAxes: [{
-              type: 'time',
-              time: {
-                unit: 'day'
-              }
-            }],
-            yAxes: [{
-              ticks: {
-                beginAtZero: true,
-                min: 0,
-                precision: 0
-              }
-            }]
-          }
+          maintainAspectRatio: false,
+          scales: { y: { beginAtZero: true, min: 0, ticks: { precision: 0 } } }
         }
-      }
-      var historyContainer = history.parent();
-
-      var $historyContainer = $(historyContainer);
-      history.attr('width', $historyContainer.width());
-      history.attr('height', $historyContainer.height());
-      taskHistoryChart = new Chart(htx, htxOpts);
+      });
     } else {
       taskHistoryChart.data = taskChartData;
-      taskHistoryChart.update(0);
+      taskHistoryChart.update('none');
     }
   }
 
@@ -185,160 +97,96 @@
     $.ajax({
       url: '/task-history',
       type: 'post',
-      data: {period},
+      data: { period },
       dataType: 'json',
       success: function(data) {
-        taskChartData = {
+        historyCanvas({
           labels: data.dates,
-          datasets: [
-            {
-              label: 'Tasks',
-              data: data.data,
-              fill: false
-            }
-          ]
-        };
-
-        max = Math.max.apply(Math, data.data);
-
-        historyCanvas();
+          datasets: [{ label: 'Tasks', data: data.data, fill: false }]
+        });
       }
     });
-  };
+  }
+
+  function getTInterval() {
+    let val = $('.taskDayFilters.active').attr('length');
+    switch (val) {
+      case '-1': updateHistory(365); break;
+      case '2': updateHistory(60); break;
+      case '3': updateHistory(90); break;
+      case '6': updateHistory(183); break;
+      default: updateHistory(30);
+    }
+    taskHistoryTimeout = setTimeout(getTInterval, 3000);
+  }
 
   $('.taskDayFilters').on('click', function(e) {
     e.preventDefault();
     $('.taskDayFilters.active').removeClass('active');
     $(this).addClass('active');
-    if (taskHistoryTimeout) {
-      clearTimeout(taskHistoryTimeout);
-    }
+    if (taskHistoryTimeout) clearTimeout(taskHistoryTimeout);
     getTInterval();
   });
 
-  getTInterval();
+  if ($('#taskHistory').length) getTInterval();
 
-  // Bandwidth
+  // Bandwidth (category x-axis)
   let bandwidthChart,
+    bandwidthChartData,
     bandwidthinterval,
     bandwidthajax;
-  function addBandwidthData(chart, label, data) {
-    chart.data.labels.push(label);
-    chart.data.datasets.forEach((dataset) => {
-      dataset.data.push(data);
-    });
-    chart.update();
-  }
-  function remBandwidthData(chart) {
-    chart.data.labels.pop();
-    chart.data.datasets.forEach((dataset) => {
-      dataset.data.pop();
-    });
-    chart.update();
-  }
+
   function bandwidthCanvas() {
-    var bandwidth = $('#bandwidth');
-    var btx = bandwidth.get(0).getContext('2d');
-    var btxOpts = {
+    let bandwidth = $('#bandwidth').get(0);
+    if (!bandwidth) return;
+    bandwidthChart = new Chart(bandwidth.getContext('2d'), {
       type: 'line',
       data: bandwidthChartData,
       options: {
         responsive: true,
-        scales: {
-          xAxes: [{
-            type: 'time',
-            time: {
-              unit: 'second'
-            }
-          }],
-          yAxes: [{
-            ticks: {
-              beginAtZero: true,
-              min: 0,
-              precision: 0
-            }
-          }]
-        }
+        maintainAspectRatio: false,
+        scales: { y: { beginAtZero: true, min: 0, ticks: { precision: 0 } } }
       }
-    };
-    var bandwidthContainer = bandwidth.parent();
-    var $bandwidthContainer = $(bandwidthContainer);
-    bandwidth.attr('width', $bandwidthContainer.width());
-    bandwidth.attr('height', $bandwidthContainer.height());
-    bandwidthChart = new Chart(btx, btxOpts);
+    });
   }
+
+  function addBandwidthData(chart, label, value) {
+    chart.data.labels.push(label);
+    chart.data.datasets.forEach((dataset) => dataset.data.push(value));
+    if (chart.data.labels.length > 30) {
+      chart.data.labels.shift();
+      chart.data.datasets.forEach((dataset) => dataset.data.shift());
+    }
+    chart.update('none');
+  }
+
   function updateBandwidth() {
-
-    // Fetches the data.
     function fetchData() {
-
-      // When ajax receives data, this updates the graph.
-      function onDataReceived(series) {
-
-        // Setup our Time elements.
-        var d = new Date(),
-          n = d.getTime();
-
-        let rate = Math.round(series.netstats[0].tx_sec / 1024 / 1024 * 8, 2);
-        if (!bandwidthChart) {
-          bandwidthChartData = {
-            labels: [
-              n
-            ],
-            datasets: [
-              {
-                label: series.netstats[0].iface + ' Mbps',
-                data: [
-                  0
-                ],
-                fill: false
-              }
-            ]
-          }
-          bandwidthCanvas();
-        } else {
-          addBandwidthData(bandwidthChart, n, rate);
-        }
-      }
       bandwidthajax = $.ajax({
         url: '/bandwidth',
         type: 'get',
         dataType: 'json',
-        beforeSend: () => {
-          if (bandwidthajax) {
-            bandwidthajax.abort();
-          }
-          if (bandwidthinterval) {
-            clearTimeout(bandwidthinterval);
+        success: function(series) {
+          if (!series || !series.netstats || !series.netstats[0]) return;
+          let label = new Date().toLocaleTimeString(),
+            rate = Math.round(series.netstats[0].tx_sec / 1024 / 1024 * 8);
+          if (!bandwidthChart) {
+            bandwidthChartData = {
+              labels: [label],
+              datasets: [{ label: series.netstats[0].iface + ' Mbps', data: [rate], fill: false }]
+            };
+            bandwidthCanvas();
+          } else {
+            addBandwidthData(bandwidthChart, label, rate);
           }
         },
-        success: onDataReceived,
-        complete: () => {}
+        complete: function() {
+          bandwidthinterval = setTimeout(fetchData, 2000);
+        }
       });
-
-      bandwidthinterval = setTimeout(fetchData, 1000);
     }
-
-    // Actually fetch our data.
     fetchData();
   }
-  // If the user presses the off button, we should stop
-  // displaying, notice we still collect data, we just don't
-  // display it. When you press on again, it should update
-  // with your missed data.
-  $('#realtime .btn').on('click', (e) => {
-    let selected = $(this).data('toggle');
-    if (selected === 'on' && realtime === 'on') {
-      return;
-    } else if (selected) {
-      realtime = 'on';
-      $('#btn-off').removeClass('active');
-      $('#btn-on').addClass('active');
-    } else {
-      realtime = 'off';
-      $('#btn-off').addClass('active');
-      $('#btn-on').removeClass('active');
-    }
-  });
-  updateBandwidth();
+
+  if ($('#bandwidth').length) updateBandwidth();
 })(jQuery);


### PR DESCRIPTION
The dashboard doughnuts/cards were blank. Multiple pre-existing causes:

- **Disk always 0:** the controller returned synchronously with `free/used/size = 0` while the real values were computed in a `checkDiskSpace().then()` that lost the race. Now awaits disk space (falls back to FS root when the image path is absent, e.g. dev).
- **`systeminformation@5` renames:** `currentLoad().avgload` → `avgLoad`; `networkInterfaces()` entries use `iface` (was `ifaceName`) → CPU load + server IP resolve.
- **Chart.js missing/v2:** `copy.js` pulled `Chart.bundle.min.js` from AdminLTE 3's tree (gone in v4). Now vendors `chart.js@4`'s `chart.umd.min.js`; drops the v2-only `chartjs-plugin-labels`.
- **Charts rewritten for Chart.js v4:** doughnuts show the % in the legend labels; line charts use a category x-axis (no time adapter dep).
- `readable-bytes` guards 0 / non-finite input.

## Verified
Disk free/used are real, `/js/chart.umd.min.js` → 200, dashboard renders with no server errors. Visual chart rendering to be confirmed in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)