### PR TITLE
feat(web): delete from list + robust columns; fix Host list

### DIFF
--- a/assets/fog/fog.common.js
+++ b/assets/fog/fog.common.js
@@ -31,7 +31,36 @@ $.fn.registerTable = function(onSelect, opts) {
           dt.clear().draw();
           dt.ajax.reload();
         }
+      },
+      {
+        text: '<i class="fa fa-trash"></i> Delete',
+        className: 'btn-danger',
+        action: function(e, dt, node, config) {
+          let ids = dt.rows({selected: true}).data().toArray().map((r) => r.id).filter(Boolean);
+          if (!ids.length) {
+            window.alert('Select one or more rows to delete.');
+            return;
+          }
+          if (!window.confirm(`Delete ${ids.length} selected item(s)? This cannot be undone.`)) {
+            return;
+          }
+          let base = dt.ajax.url().replace(/\/datatable.*$/, '');
+          $.ajax({
+            url: base,
+            type: 'DELETE',
+            contentType: 'application/json',
+            data: JSON.stringify({id: ids}),
+            complete: function() {
+              dt.ajax.reload();
+            }
+          });
+        }
       }
+    ],
+    // Render a missing/association field as empty instead of throwing the
+    // DataTables "Requested unknown parameter" warning.
+    columnDefs: [
+      { targets: '_all', defaultContent: '' }
     ],
     pagingType: 'simple_numbers',
     select: {

--- a/views/pages/partials/list/host.js
+++ b/views/pages/partials/list/host.js
@@ -1,16 +1,30 @@
 (function($) {
   let path = $(location).attr('pathname').replace(/s$/,'');
-  console.log(path);
   $('#listtable').registerTable(undefined, {
     order: [
       [0, 'asc']
     ],
     columns: [
       {data: 'name'},
-      {data: 'primac'},
+      {
+        data: 'macs',
+        orderable: false,
+        render: function(data) {
+          if (Array.isArray(data)) {
+            return data.length ? data[0] : '';
+          }
+          return data || '';
+        }
+      },
       {data: 'pingstatus'},
       {data: 'deployed'},
-      {data: 'image'},
+      {
+        data: 'image',
+        orderable: false,
+        render: function(data) {
+          return (data && data.name) ? data.name : '';
+        }
+      },
       {data: 'description'}
     ],
     rowId: 'id',


### PR DESCRIPTION
## Host list was erroring
The Host list partial referenced a `primac` column that doesn't exist on Host records → DataTables threw *"Requested unknown parameter 'primac'"*.

## Changes
- **Delete from the UI:** a "Delete" button in the shared DataTables config deletes the selected rows in one bulk `DELETE /api/v1/<model>` (derived from the table's ajax url), with a confirm, then reloads.
- **Robust columns:** global `columnDefs` `defaultContent: ''` so a missing/association field renders empty instead of throwing.
- **Fix Host columns:** render the primary MAC from `macs` (string or array) and the assigned image from the `image` association name.

## Verified
Host list renders data; bulk delete removes selected rows (count 1 → 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)