### PR TITLE
feat(web): edit pages (complete CRUD)

### DIFF
--- a/api/controllers/general/save.js
+++ b/api/controllers/general/save.js
@@ -1,9 +1,9 @@
 module.exports = {
   friendlyName: 'Save',
-  description: 'Handle a server-rendered create form POST (e.g. POST /groups/create).',
+  description: 'Handle a server-rendered create/edit form POST (e.g. POST /groups/create or POST /groups/edit/:id).',
   exits: {
     success: {
-      description: 'Record created; redirected to the list.'
+      description: 'Record created/updated; redirected to the list.'
     },
     error: {
       responseType: 'serverError'
@@ -15,29 +15,51 @@ module.exports = {
       // Derive the model from the URL, e.g. /groups/create -> group
       segments = req.path.split('/').filter(Boolean),
       plural = segments[0],
-      model = plural.replace(/s$/, '');
+      model = plural.replace(/s$/, ''),
+      id = req.param('id'),
+      isUpdate = !!id;
 
     if (!model || !sails.models[model]) {
       res.notFound();
       return res.end();
     }
 
-    // Permission: the generic `create` policy can't run here (no :model param),
-    // so check the create permission for the derived model directly.
-    if (!_.get(req, 'user.permissions.stock.' + model + '.create')) {
+    // Permission: the generic create/update policies can't run here (no :model
+    // param), so check the relevant permission for the derived model directly.
+    let perm = isUpdate ? 'update' : 'create';
+    if (!_.get(req, 'user.permissions.stock.' + model + '.' + perm)) {
       res.forbidden();
       return res.end();
     }
 
     // Build the values from the body, dropping non-attribute keys.
-    let values = _.omit(req.allParams(), ['model', '_csrf']);
+    let values = _.omit(req.allParams(), ['model', '_csrf', 'id']);
+
+    // A checkbox paired with a hidden field submits an array (["false","true"]
+    // when checked, "false" when not); take the last value.
+    _.forEach(values, (v, k) => {
+      if (_.isArray(v)) {
+        values[k] = v[v.length - 1];
+      }
+    });
+
+    // Coerce boolean attributes from their string form so Waterline accepts them.
+    let attrs = sails.models[model].attributes;
+    _.forEach(values, (v, k) => {
+      if (attrs[k] && attrs[k].type === 'boolean') {
+        values[k] = (v === true || v === 'true' || v === 'on' || v === '1');
+      }
+    });
 
     try {
-      await sails.models[model].create(values)
-        .intercept('E_UNIQUE', () => 'unique')
-        .intercept({ name: 'UsageError' }, () => 'usage');
+      if (isUpdate) {
+        await sails.models[model].updateOne({ id }).set(values);
+      } else {
+        await sails.models[model].create(values);
+      }
     } catch (unused) {
-      return res.redirect(`/${plural}/create?failed=1`);
+      let back = isUpdate ? `/${plural}/edit/${id}` : `/${plural}/create`;
+      return res.redirect(`${back}?failed=1`);
     }
 
     return res.redirect(`/${plural}`);

--- a/api/controllers/pages/edit.js
+++ b/api/controllers/pages/edit.js
@@ -1,0 +1,84 @@
+/**
+ * Generic edit page.
+ *
+ * Handles GET /<plural>/edit/:id for any model: loads the record and builds an
+ * edit form from the model's scalar attributes (associations, system fields,
+ * password and permissions are skipped). Submits to POST /<plural>/edit/:id,
+ * which is handled by general/save.
+ */
+module.exports = {
+  friendlyName: 'Edit',
+  description: 'Display a generic edit form for a record.',
+  exits: {
+    success: {
+      viewTemplatePath: 'pages/create'
+    },
+    notFound: {
+      responseType: 'notFound'
+    }
+  },
+  fn: async function () {
+    let req = this.req,
+      segments = req.path.split('/').filter(Boolean),
+      plural = segments[0],
+      model = plural.replace(/s$/, ''),
+      id = req.param('id'),
+      skip = ['id', 'createdAt', 'updatedAt', 'password', 'permissions'];
+
+    if (!model || !sails.models[model]) {
+      throw 'notFound';
+    }
+
+    let record = await sails.models[model].findOne({ id });
+    if (!record) {
+      throw 'notFound';
+    }
+
+    let attrs = sails.models[model].attributes,
+      formItems = {};
+    Object.keys(attrs).forEach((key) => {
+      let attr = attrs[key];
+      if (attr.collection || attr.model) { return; } // associations
+      if (skip.includes(key)) { return; }
+
+      let label = key.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase()),
+        val = record[key],
+        item = { text: label, id: `${model}-${key}`, classes: [], textarea: false };
+
+      if (attr.type === 'boolean') {
+        item.type = 'checkbox';
+        item.checked = !!val;
+      } else if (attr.type === 'number') {
+        item.type = 'number';
+        item.value = (val === undefined || val === null) ? '' : val;
+      } else {
+        item.type = 'text';
+        if (key === 'description') { item.textarea = true; }
+        if (val !== null && typeof val === 'object') { val = JSON.stringify(val); }
+        item.value = (val === undefined || val === null) ? '' : val;
+      }
+      formItems[key] = item;
+    });
+
+    let title = model.charAt(0).toUpperCase() + model.slice(1),
+      data = {
+        model,
+        header: `Edit ${title}`,
+        title: `Edit ${title}`,
+        partialname: false
+      };
+    data.form = await sails.helpers.formGenerator.with({
+      model,
+      method: 'post',
+      action: `/${plural}/edit/${id}`,
+      id: `${model}-edit`,
+      classes: [`${model}-edit-form`],
+      formItems,
+      formButtons: {
+        Cancel: { classes: ['btn-warning', 'float-start'], type: 'submit' },
+        Save: { classes: ['btn-success', 'float-end'], type: 'submit' }
+      }
+    });
+    return data;
+  }
+};

--- a/api/helpers/form-generator.js
+++ b/api/helpers/form-generator.js
@@ -156,7 +156,8 @@ module.exports = {
                   <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
                   <div class="col-sm-10">
                     <div class="form-check mt-2">
-                      <input type="checkbox" class="form-check-input${iClass}"${iId}${iName}${iChecked}/>
+                      <input type="hidden"${iName} value="false"/>
+                      <input type="checkbox" class="form-check-input${iClass}"${iId}${iName} value="true"${iChecked}/>
                     </div>
                   </div>
                 </div>

--- a/assets/fog/fog.common.js
+++ b/assets/fog/fog.common.js
@@ -33,6 +33,18 @@ $.fn.registerTable = function(onSelect, opts) {
         }
       },
       {
+        text: '<i class="fa fa-edit"></i> Edit',
+        action: function(e, dt, node, config) {
+          let rows = dt.rows({selected: true}).data().toArray();
+          if (rows.length !== 1) {
+            window.alert('Select exactly one row to edit.');
+            return;
+          }
+          let base = window.location.pathname.replace(/\/$/, '');
+          window.location = `${base}/edit/${rows[0].id}`;
+        }
+      },
+      {
         text: '<i class="fa fa-trash"></i> Delete',
         className: 'btn-danger',
         action: function(e, dt, node, config) {

--- a/config/routes.js
+++ b/config/routes.js
@@ -112,6 +112,26 @@ module.exports.routes = {
   'GET /pxemenus/create':                    {action: 'pages/create/pxemenus'},
   'POST /pxemenus/create':                   {action: 'general/save'},
 
+  // Edit Views (generic edit page + save)
+  'GET /hosts/edit/:id':                      {action: 'pages/edit'},
+  'POST /hosts/edit/:id':                     {action: 'general/save'},
+  'GET /groups/edit/:id':                     {action: 'pages/edit'},
+  'POST /groups/edit/:id':                    {action: 'general/save'},
+  'GET /images/edit/:id':                     {action: 'pages/edit'},
+  'POST /images/edit/:id':                    {action: 'general/save'},
+  'GET /storagegroups/edit/:id':             {action: 'pages/edit'},
+  'POST /storagegroups/edit/:id':            {action: 'general/save'},
+  'GET /storagenodes/edit/:id':              {action: 'pages/edit'},
+  'POST /storagenodes/edit/:id':             {action: 'general/save'},
+  'GET /snapins/edit/:id':                    {action: 'pages/edit'},
+  'POST /snapins/edit/:id':                   {action: 'general/save'},
+  'GET /printers/edit/:id':                   {action: 'pages/edit'},
+  'POST /printers/edit/:id':                  {action: 'general/save'},
+  'GET /pxemenus/edit/:id':                   {action: 'pages/edit'},
+  'POST /pxemenus/edit/:id':                  {action: 'general/save'},
+  'GET /users/edit/:id':                      {action: 'pages/edit'},
+  'POST /users/edit/:id':                     {action: 'general/save'},
+
   // Role Views
   'GET /roles':                              {action: 'pages/list/roles'},
 


### PR DESCRIPTION
Completes CRUD with edit pages.

- **Generic `pages/edit`**: `GET /<plural>/edit/:id` loads the record and auto-builds an edit form from the model's scalar attributes with current values (associations, id/timestamps, password, permissions skipped).
- **`general/save` now updates**: with an `:id` it checks the `update` permission and `updateOne()`s; normalises checkbox arrays and coerces booleans.
- **form-generator**: pairs each checkbox with a hidden `false` input so unchecking submits `false` (edits can turn booleans off).
- **"Edit" button** in the shared DataTables config (edits the single selected row).
- **Routes**: `GET`/`POST /<plural>/edit/:id` for host, group, image, user, storagegroup, storagenode, snapin, printer, pxemenu.

## Verified (live)
Edit page pre-fills values; save updates + redirects to the list; booleans can be checked and unchecked.

## Notes / limitations
Edit covers scalar fields only — associations (e.g. host's image/groups), `password`, and `permissions` are intentionally not in the generic form yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)