### PR TITLE
feat(web): universal (global) search across entities

### DIFF
--- a/api/controllers/pages/search.js
+++ b/api/controllers/pages/search.js
@@ -1,0 +1,25 @@
+module.exports = {
+  friendlyName: 'Search',
+  description: 'Global search results page.',
+  exits: {
+    success: {
+      viewTemplatePath: 'pages/search'
+    }
+  },
+  fn: async function () {
+    let req = this.req,
+      q = req.param('q') || '',
+      groups = await sails.helpers.globalSearch.with({
+        q,
+        permissions: _.get(req, 'user.permissions') || {}
+      });
+    return {
+      title: q ? `Search: ${q}` : 'Search',
+      header: q ? `Search results for "${q}"` : 'Search',
+      model: 'search',
+      partialname: false,
+      q,
+      groups
+    };
+  }
+};

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -1,0 +1,12 @@
+module.exports = {
+  friendlyName: 'Search (API)',
+  description: 'Global search across user-facing models (JSON), filtered by read permissions.',
+  fn: async function () {
+    let req = this.req,
+      q = req.param('q') || '';
+    return await sails.helpers.globalSearch.with({
+      q,
+      permissions: _.get(req, 'user.permissions') || {}
+    });
+  }
+};

--- a/api/helpers/global-search.js
+++ b/api/helpers/global-search.js
@@ -1,0 +1,86 @@
+module.exports = {
+  friendlyName: 'Global search',
+  description: 'Search across the user-facing models, filtered by the caller\'s read permissions.',
+  inputs: {
+    q: {
+      type: 'string',
+      defaultsTo: ''
+    },
+    permissions: {
+      description: 'The caller\'s resolved permissions object (req.user.permissions).',
+      type: 'ref',
+      defaultsTo: {}
+    },
+    limit: {
+      type: 'number',
+      defaultsTo: 10
+    }
+  },
+  exits: {
+    success: {
+      outputFriendlyName: 'Result groups'
+    }
+  },
+  fn: async function (inputs) {
+    let q = (inputs.q || '').trim(),
+      perms = inputs.permissions || {},
+      groups = [];
+
+    if (!q) {
+      return groups;
+    }
+
+    // Escape the query so it is matched as a literal substring (no regex
+    // injection / ReDoS from user input), then match case-insensitively.
+    let escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    // The user-facing entities and which string fields to search.
+    let searchConfig = [
+      { model: 'host', label: 'Hosts', fields: ['name', 'description', 'ip'] },
+      { model: 'image', label: 'Images', fields: ['name', 'description'] },
+      { model: 'group', label: 'Groups', fields: ['name', 'description'] },
+      { model: 'snapin', label: 'Snapins', fields: ['name', 'description', 'file'] },
+      { model: 'printer', label: 'Printers', fields: ['name', 'description', 'printerModel', 'ip'] },
+      { model: 'storagegroup', label: 'Storage Groups', fields: ['name', 'description'] },
+      { model: 'storagenode', label: 'Storage Nodes', fields: ['name', 'description', 'ip'] },
+      { model: 'pxemenu', label: 'iPXE Menus', fields: ['name', 'description'] },
+      { model: 'user', label: 'Users', fields: ['username', 'email', 'displayName'] }
+    ];
+
+    for (let cfg of searchConfig) {
+      let Model = sails.models[cfg.model];
+      if (!Model) { continue; }
+      // Permission gate: only search models the caller can read.
+      if (!_.get(perms, 'stock.' + cfg.model + '.read')) { continue; }
+
+      let fields = cfg.fields.filter((f) => !_.isUndefined(Model.attributes[f]));
+      if (!fields.length) { continue; }
+
+      try {
+        // Use the native Mongo collection for a case-insensitive regex search
+        // (Waterline's `contains` is case-sensitive under sails-mongo).
+        let db = sails.getDatastore(Model.datastore).manager,
+          collection = db.collection(Model.tableName),
+          docs = await collection
+            .find({ $or: fields.map((f) => ({ [f]: { $regex: escaped, $options: 'i' } })) })
+            .limit(inputs.limit)
+            .toArray();
+        if (docs.length) {
+          groups.push({
+            model: cfg.model,
+            label: cfg.label,
+            plural: cfg.model + 's',
+            items: docs.map((d) => ({
+              id: String(d._id),
+              name: d.name || d.username || String(d._id)
+            }))
+          });
+        }
+      } catch (err) {
+        sails.log.warn(`globalSearch: ${cfg.model} search failed: ${err.message}`);
+      }
+    }
+
+    return groups;
+  }
+};

--- a/config/routes.js
+++ b/config/routes.js
@@ -52,6 +52,9 @@ module.exports.routes = {
   // User API
   'GET /api/v1/user/me':                     {action: 'user/listme'},
 
+  // Global search (must precede the :model routes).
+  'GET /api/v1/search':                      {action: 'search'},
+
   // General API elements.
   'POST /api/v1/:model':                     {action: 'general/create'},
   'DELETE /api/v1/:model/:id?':              {action: 'general/destroy'},
@@ -71,6 +74,9 @@ module.exports.routes = {
   // Dashboard View
   'GET /':                                   {action: 'pages/dashboard'},
   'POST /task-history':                      {action: 'task-history'},
+
+  // Search View
+  'GET /search':                             {action: 'pages/search'},
 
   // Group Views
   'GET /groups':                             {action: 'pages/list/groups'},

--- a/views/layouts/partials/sidebar.ejs
+++ b/views/layouts/partials/sidebar.ejs
@@ -1,5 +1,16 @@
 <!-- Sidebar Menu -->
 <% if (req.user) { %>
+<!-- Sidebar global search -->
+<div class="p-2">
+  <form action="/search" method="get" role="search">
+    <div class="input-group input-group-sm">
+      <input class="form-control" type="search" name="q" placeholder="Search..." aria-label="Search">
+      <button class="btn btn-primary" type="submit">
+        <i class="fa fa-search"></i>
+      </button>
+    </div>
+  </form>
+</div>
 <nav class="mt-2">
   <ul class="nav sidebar-menu flex-column" data-lte-toggle="treeview" role="menu" data-accordion="false">
     <% for (var i = 0; i < menuItems.length; i++) { %>

--- a/views/pages/search.ejs
+++ b/views/pages/search.ejs
@@ -1,0 +1,40 @@
+<div class="app-content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <h3 class="mb-0"><%= header %></h3>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="app-content">
+  <div class="container-fluid">
+    <% if (!q) { %>
+    <div class="card">
+      <div class="card-body">Enter a term in the search box to look across hosts, images, groups, snapins, printers, storage and more.</div>
+    </div>
+    <% } else if (!groups.length) { %>
+    <div class="card">
+      <div class="card-body">No results for "<%= q %>".</div>
+    </div>
+    <% } else { %>
+    <% groups.forEach(function(g) { %>
+    <div class="card card-info card-outline">
+      <div class="card-header">
+        <h3 class="card-title"><%= g.label %> (<%= g.items.length %>)</h3>
+      </div>
+      <div class="card-body p-0">
+        <ul class="list-group list-group-flush">
+          <% g.items.forEach(function(it) { %>
+          <li class="list-group-item">
+            <a href="/<%= g.plural %>/edit/<%= it.id %>"><%= it.name %></a>
+          </li>
+          <% }); %>
+        </ul>
+      </div>
+    </div>
+    <% }); %>
+    <% } %>
+  </div>
+</div>
+<%- /* Expose server-rendered data as window.SAILS_LOCALS :: */ exposeLocalsToBrowser() %>


### PR DESCRIPTION
Restores a search box in the sidebar — but a **real global DB search** like FOG 1.x, not just a menu filter.

- **`helpers/global-search`**: searches user-facing models and **only the ones the caller can read** (`req.user.permissions.stock.<model>.read`). Uses the native Mongo collection for a **case-insensitive** `$regex` (Waterline `contains` is case-sensitive under sails-mongo); the query is **escaped** to a literal substring (no regex injection).
- **`pages/search` + `views/pages/search.ejs`**: grouped results page linking to each match's edit page.
- **`GET /api/v1/search`** JSON API (declared before `:model`).
- **Sidebar search form** (`GET /search`).

## Verified
Case-insensitive matches across models; results link to edit pages; `.*` matches literally (escaping); empty/no-result states handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)