### PR TITLE
fix(model): host guid should not be unique/UUID-required

### DIFF
--- a/api/models/Host.js
+++ b/api/models/Host.js
@@ -16,10 +16,12 @@ module.exports = {
     description: {
       type: 'string'
     },
+    // NOTE: not `unique` and not `isUUID`. A unique index on an optional field
+    // makes every host created without a guid collide (empty/null guids are
+    // "equal"), which 409s the 2nd host; and isUUID rejects the empty string on
+    // edit. The hardware guid is set/validated at registration time instead.
     guid: {
-      type: 'string',
-      isUUID: true,
-      unique: true
+      type: 'string'
     },
     macs: {
       type: 'json'


### PR DESCRIPTION
`Host.guid` was `unique: true` + `isUUID: true` but **optional**. A unique index on an optional field treats every missing/empty guid as equal, so **creating a second host without a guid 409'd**; and `isUUID` rejected the empty string when editing a host.

Make `guid` a plain optional string (the hardware guid is set/validated at registration). sails-mongo drops the now-stale unique index on the next lift (`migrate: alter`).

## Verified
Two hosts created without a guid (200, 200); the unique `guid` index is gone after lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)