### PR TITLE
feat(web): live search dropdown (results as you type)

### DIFF
--- a/assets/fog/fog.search.js
+++ b/assets/fog/fog.search.js
@@ -1,0 +1,56 @@
+// Live global-search dropdown for the sidebar search box.
+(function($) {
+  let $input = $('#globalSearchInput');
+  if (!$input.length) {
+    return;
+  }
+  let $results = $('#globalSearchResults'),
+    timer = null;
+
+  function esc(s) {
+    return $('<div>').text(s == null ? '' : s).html();
+  }
+
+  function render(groups) {
+    if (!groups || !groups.length) {
+      $results.html('<div class="px-2 py-1 text-muted small">No results</div>').show();
+      return;
+    }
+    let html = '';
+    groups.forEach(function(g) {
+      html += `<div class="px-2 py-1 small fw-bold text-muted bg-light">${esc(g.label)}</div>`;
+      g.items.forEach(function(it) {
+        html += `<a class="d-block px-2 py-1 text-decoration-none text-dark border-bottom text-truncate" href="/${g.plural}/edit/${it.id}">${esc(it.name)}</a>`;
+      });
+    });
+    $results.html(html).show();
+  }
+
+  $input.on('input', function() {
+    let q = $.trim($input.val());
+    if (timer) {
+      clearTimeout(timer);
+    }
+    if (q.length < 2) {
+      $results.hide().empty();
+      return;
+    }
+    timer = setTimeout(function() {
+      $.ajax({ url: '/api/v1/search', data: { q: q }, dataType: 'json' })
+        .done(render)
+        .fail(function() { $results.hide(); });
+    }, 250);
+  });
+
+  $input.on('focus', function() {
+    if ($results.children().length) {
+      $results.show();
+    }
+  });
+
+  $(document).on('click', function(e) {
+    if (!$(e.target).closest('#globalSearchWrap').length) {
+      $results.hide();
+    }
+  });
+})(jQuery);

--- a/views/layouts/partials/sidebar.ejs
+++ b/views/layouts/partials/sidebar.ejs
@@ -1,15 +1,16 @@
 <!-- Sidebar Menu -->
 <% if (req.user) { %>
 <!-- Sidebar global search -->
-<div class="p-2">
+<div class="p-2 position-relative" id="globalSearchWrap">
   <form action="/search" method="get" role="search">
     <div class="input-group input-group-sm">
-      <input class="form-control" type="search" name="q" placeholder="Search..." aria-label="Search">
+      <input id="globalSearchInput" class="form-control" type="search" name="q" placeholder="Search..." aria-label="Search" autocomplete="off">
       <button class="btn btn-primary" type="submit">
         <i class="fa fa-search"></i>
       </button>
     </div>
   </form>
+  <div id="globalSearchResults" class="position-absolute bg-white border rounded shadow-sm" style="display:none; left:0.5rem; right:0.5rem; z-index:1050; max-height:320px; overflow:auto;"></div>
 </div>
 <nav class="mt-2">
   <ul class="nav sidebar-menu flex-column" data-lte-toggle="treeview" role="menu" data-accordion="false">


### PR DESCRIPTION
Adds the 1.x-style as-you-type feel: a debounced client calls `GET /api/v1/search` (>=2 chars) and renders grouped results in a dropdown under the sidebar search box; clicking goes to the edit page. Enter/button still opens the full results page. Result text is escaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)