### PR TITLE
feat(web): MAC address list widget (multiple + primary)

### DIFF
--- a/api/controllers/general/save.js
+++ b/api/controllers/general/save.js
@@ -33,20 +33,18 @@ module.exports = {
     }
 
     // Build the values from the body, dropping non-attribute keys.
-    let values = _.omit(req.allParams(), ['model', '_csrf', 'id']);
+    let values = _.omit(req.allParams(), ['model', '_csrf', 'id', '__primac']);
 
-    // A checkbox paired with a hidden field submits an array (["false","true"]
-    // when checked, "false" when not); take the last value.
-    _.forEach(values, (v, k) => {
-      if (_.isArray(v)) {
-        values[k] = v[v.length - 1];
-      }
-    });
-
-    // Coerce boolean attributes from their string form so Waterline accepts them.
+    // Normalise boolean attributes only. A checkbox paired with a hidden field
+    // submits an array (["false","true"] when checked, "false" when not) -- take
+    // the last value, then coerce to a real boolean. Legitimate array fields
+    // (e.g. a json `macs` list) are left untouched.
     let attrs = sails.models[model].attributes;
     _.forEach(values, (v, k) => {
       if (attrs[k] && attrs[k].type === 'boolean') {
+        if (_.isArray(v)) {
+          v = v[v.length - 1];
+        }
         values[k] = (v === true || v === 'true' || v === 'on' || v === '1');
       }
     });

--- a/api/controllers/pages/create/hosts.js
+++ b/api/controllers/pages/create/hosts.js
@@ -26,16 +26,11 @@ module.exports = {
           },
           macs: {
             textarea: false,
-            text: 'MAC Address',
-            type: 'text',
-            validations: {
-              minLength: 12,
-              maxLength: 17,
-              regex: /^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})|([0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4})$/,
-            },
+            text: 'MAC Addresses',
+            type: 'maclist',
             id: 'macaddress',
             classes: [],
-            placeholder: 'AA:BB:CC:DD:EE:FF'
+            value: []
           },
           description: {
             textarea: true,

--- a/api/controllers/pages/edit.js
+++ b/api/controllers/pages/edit.js
@@ -41,6 +41,19 @@ module.exports = {
       if (attr.collection || attr.model) { return; } // associations
       if (skip.includes(key)) { return; }
 
+      // Host MACs get a dedicated multi-value widget with a primary picker.
+      if (model === 'host' && key === 'macs') {
+        formItems[key] = {
+          text: 'MAC Addresses',
+          id: `${model}-macs`,
+          classes: [],
+          textarea: false,
+          type: 'maclist',
+          value: Array.isArray(record[key]) ? record[key] : (record[key] ? [record[key]] : [])
+        };
+        return;
+      }
+
       let label = key.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase()),
         val = record[key],
         item = { text: label, id: `${model}-${key}`, classes: [], textarea: false };

--- a/api/helpers/form-generator.js
+++ b/api/helpers/form-generator.js
@@ -173,6 +173,33 @@ module.exports = {
                 </div>
               `
               break;
+            case 'maclist': {
+              let macs = Array.isArray(input.value) ? input.value : (input.value ? [input.value] : []);
+              if (!macs.length) { macs = ['']; }
+              form += `
+                <div class="row mb-3">
+                  <label class="col-sm-2 col-form-label">${input.text}</label>
+                  <div class="col-sm-10">
+                    <div data-maclist>`;
+              macs.forEach((m, idx) => {
+                form += `
+                      <div class="input-group mb-1 maclist-row">
+                        <div class="input-group-text">
+                          <input type="radio" name="__primac" title="Primary MAC"${idx === 0 ? ' checked' : ''}/>
+                        </div>
+                        <input type="text" class="form-control" name="macs[]" value="${m}" placeholder="AA:BB:CC:DD:EE:FF"/>
+                        <button type="button" class="btn btn-outline-danger maclist-remove" tabindex="-1">&times;</button>
+                      </div>`;
+              });
+              form += `
+                      <button type="button" class="btn btn-sm btn-secondary maclist-add">+ Add MAC</button>
+                    </div>
+                    <small class="form-text text-muted">Select the radio of the primary MAC.</small>
+                  </div>
+                </div>
+              `;
+              break;
+            }
             default:
               form += `
                 <div class="row mb-3">

--- a/assets/fog/fog.maclist.js
+++ b/assets/fog/fog.maclist.js
@@ -1,0 +1,47 @@
+// MAC-address list widget for host create/edit forms.
+// Rows of MAC inputs (name="macs[]") with a radio to pick the primary; on submit
+// the primary row is moved to the front (index 0 = primary) and empty rows are
+// dropped.
+(function($) {
+  function rowHtml() {
+    return `
+      <div class="input-group mb-1 maclist-row">
+        <div class="input-group-text">
+          <input type="radio" name="__primac" title="Primary MAC"/>
+        </div>
+        <input type="text" class="form-control" name="macs[]" placeholder="AA:BB:CC:DD:EE:FF"/>
+        <button type="button" class="btn btn-outline-danger maclist-remove" tabindex="-1">&times;</button>
+      </div>`;
+  }
+
+  $(document).on('click', '.maclist-add', function() {
+    $(this).before(rowHtml());
+  });
+
+  $(document).on('click', '.maclist-remove', function() {
+    let $list = $(this).closest('[data-maclist]'),
+      $row = $(this).closest('.maclist-row'),
+      wasPrimary = $row.find('input[name="__primac"]').is(':checked');
+    $row.remove();
+    // Keep a primary selected.
+    if (wasPrimary && !$list.find('input[name="__primac"]:checked').length) {
+      $list.find('input[name="__primac"]').first().prop('checked', true);
+    }
+  });
+
+  $(document).on('submit', 'form', function() {
+    let $list = $(this).find('[data-maclist]');
+    if (!$list.length) { return; }
+    // Drop empty MAC rows.
+    $list.find('.maclist-row').each(function() {
+      if (!$.trim($(this).find('input[name="macs[]"]').val())) {
+        $(this).remove();
+      }
+    });
+    // Move the primary (checked radio) row to the top so it submits first.
+    let $primary = $list.find('input[name="__primac"]:checked').closest('.maclist-row');
+    if ($primary.length) {
+      $list.prepend($primary);
+    }
+  });
+})(jQuery);


### PR DESCRIPTION
Host MACs are a json array (index 0 = primary). Replaces the single text field with a real widget on host create/edit.

- **form-generator**: new `maclist` field type → rows of `macs[]` inputs, each with a radio to mark the **primary**, plus add/remove buttons.
- **`assets/fog/fog.maclist.js`**: add/remove rows; on submit, drop empties and move the primary row to the front (stored first).
- Host **create** + generic **edit** (host.macs special-case) use the widget.
- **`general/save`**: only collapse boolean checkbox arrays; leave genuine arrays like `macs` intact (and ignore the `__primac` helper field).

## Verified
Creating a host with multiple MACs stores an ordered array (primary first); the edit page pre-fills all MACs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)