### PR TITLE
fix(web): drop empty MACs server-side (primary not blank)

### DIFF
--- a/api/controllers/general/save.js
+++ b/api/controllers/general/save.js
@@ -35,6 +35,14 @@ module.exports = {
     // Build the values from the body, dropping non-attribute keys.
     let values = _.omit(req.allParams(), ['model', '_csrf', 'id', '__primac']);
 
+    // Drop empty strings from array fields (e.g. blank rows in the MAC widget),
+    // so the primary (index 0) is never an empty value.
+    _.forEach(values, (v, k) => {
+      if (_.isArray(v)) {
+        values[k] = v.filter((el) => !(typeof el === 'string' && el.trim() === ''));
+      }
+    });
+
     // Normalise boolean attributes only. A checkbox paired with a hidden field
     // submits an array (["false","true"] when checked, "false" when not) -- take
     // the last value, then coerce to a real boolean. Legitimate array fields


### PR DESCRIPTION
If a MAC was typed in a second row while the first stayed empty, the form submitted `macs=["", "AA:.."]`, making `macs[0]` (the primary, shown in the host list) an empty string — so it looked like the MAC wasn't saved. `general/save` now drops empty-string elements from array fields before saving (server-side backstop; the widget already trims rows client-side).

Verified: `["","AA"]` → `["AA"]`; multi-MAC preserved; boolean checkbox handling unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)