### PR TITLE
fix(web): edit save failed on empty number fields (couldn't add a MAC)

### DIFF
--- a/api/controllers/general/save.js
+++ b/api/controllers/general/save.js
@@ -57,6 +57,25 @@ module.exports = {
       }
     });
 
+    // Coerce number attributes. Empty form fields arrive as "" which Waterline
+    // rejects for a number type -- omit those (leave the value unchanged on
+    // update / use the model default on create) and convert the rest.
+    _.forEach(_.keys(values), (k) => {
+      if (attrs[k] && attrs[k].type === 'number') {
+        let v = values[k];
+        if (v === '' || v === null || typeof v === 'undefined') {
+          delete values[k];
+        } else {
+          let n = Number(v);
+          if (_.isNaN(n)) {
+            delete values[k];
+          } else {
+            values[k] = n;
+          }
+        }
+      }
+    });
+
     try {
       if (isUpdate) {
         await sails.models[model].updateOne({ id }).set(values);


### PR DESCRIPTION
## Cause
The generic edit form submits number fields (`building`, `printerLevel`, …) as `""` when empty. Waterline **rejects `""` for a `number` attribute**, so `updateOne` threw and the **entire save** was rejected — which is why editing a host to add a MAC (or change anything) silently failed, while *create* worked (create forms have no number fields).

## Fix
`general/save` coerces number attributes: empty → omitted (unchanged on update / default on create), otherwise `Number()`. Applies to every model's create/edit.

## Verified
Host edit with empty numbers saves + adds MACs; `building=7` persists; a host whose `macs` was a legacy string edits correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)