### PR TITLE
feat(model): validate + normalize host MAC addresses

### DIFF
--- a/api/helpers/form-generator.js
+++ b/api/helpers/form-generator.js
@@ -187,7 +187,7 @@ module.exports = {
                         <div class="input-group-text">
                           <input type="radio" name="__primac" title="Primary MAC"${idx === 0 ? ' checked' : ''}/>
                         </div>
-                        <input type="text" class="form-control" name="macs[]" value="${m}" placeholder="AA:BB:CC:DD:EE:FF"/>
+                        <input type="text" class="form-control" name="macs[]" value="${m}" placeholder="AA:BB:CC:DD:EE:FF" pattern="[0-9A-Fa-f]{2}([:.-]?[0-9A-Fa-f]{2}){5}" title="A MAC address, e.g. AA:BB:CC:DD:EE:FF"/>
                         <button type="button" class="btn btn-outline-danger maclist-remove" tabindex="-1">&times;</button>
                       </div>`;
               });

--- a/api/models/Host.js
+++ b/api/models/Host.js
@@ -4,6 +4,43 @@
  * @description :: A model definition represents a database table/collection.
  * @docs        :: https://sailsjs.com/docs/concepts/models-and-orm/models
  */
+const MAC_HEX = /^[0-9a-fA-F]{12}$/;
+
+// Normalise + validate the `macs` json array: accept any common separator style
+// (colon/hyphen/dot) or bare 12 hex, store the canonical upper-case colon form,
+// drop blanks/dupes, and reject anything that isn't a MAC address.
+function normalizeMacs(values, proceed) {
+  if (!Object.prototype.hasOwnProperty.call(values, 'macs')) {
+    return proceed();
+  }
+  let raw = values.macs;
+  if (typeof raw === 'string') {
+    raw = raw.split(/[\s,]+/);
+  }
+  if (!Array.isArray(raw)) {
+    raw = (raw === null || typeof raw === 'undefined') ? [] : [raw];
+  }
+  let out = [];
+  for (let entry of raw) {
+    if (entry === null || typeof entry === 'undefined') {
+      continue;
+    }
+    let hex = String(entry).replace(/[\s.:-]/g, '');
+    if (hex === '') {
+      continue;
+    }
+    if (!MAC_HEX.test(hex)) {
+      return proceed(new Error(`Invalid MAC address: ${entry}`));
+    }
+    let mac = hex.toUpperCase().match(/.{2}/g).join(':');
+    if (out.indexOf(mac) === -1) {
+      out.push(mac);
+    }
+  }
+  values.macs = out;
+  return proceed();
+}
+
 module.exports = {
   attributes: {
     name: {
@@ -138,5 +175,11 @@ module.exports = {
     defaultPrinter: {
       model: 'printer'
     }
+  },
+  beforeCreate: function(values, proceed) {
+    return normalizeMacs(values, proceed);
+  },
+  beforeUpdate: function(values, proceed) {
+    return normalizeMacs(values, proceed);
   }
 };

--- a/assets/fog/fog.maclist.js
+++ b/assets/fog/fog.maclist.js
@@ -9,7 +9,7 @@
         <div class="input-group-text">
           <input type="radio" name="__primac" title="Primary MAC"/>
         </div>
-        <input type="text" class="form-control" name="macs[]" placeholder="AA:BB:CC:DD:EE:FF"/>
+        <input type="text" class="form-control" name="macs[]" placeholder="AA:BB:CC:DD:EE:FF" pattern="[0-9A-Fa-f]{2}([:.-]?[0-9A-Fa-f]{2}){5}" title="A MAC address, e.g. AA:BB:CC:DD:EE:FF"/>
         <button type="button" class="btn btn-outline-danger maclist-remove" tabindex="-1">&times;</button>
       </div>`;
   }


### PR DESCRIPTION
MACs must be valid MAC addresses, not freeform text.

- **Host `beforeCreate`/`beforeUpdate`** (authoritative — covers form *and* API): normalise the `macs` array — accept any common separator (`:` `-` `.`) or bare 12 hex, store the canonical upper-case colon form (`AA:BB:CC:DD:EE:FF`), drop blanks/dupes, and **reject** anything that isn't a MAC.
- **HTML5 `pattern` + title** on the MAC widget inputs for instant client-side feedback.

## Verified
`aa:bb:..` → `AA:BB:..`; bare `abababababab` → `AB:AB:..`; `test` and valid+garbage mixes are rejected (host not created); pattern present in the form.

Note: existing hosts with a legacy string MAC normalize to the array form on their next save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)