### PR TITLE
feat(web): consistent MAC formatting (store bare lowercase, show aa:bb..)

### DIFF
--- a/api/controllers/pages/edit.js
+++ b/api/controllers/pages/edit.js
@@ -42,14 +42,19 @@ module.exports = {
       if (skip.includes(key)) { return; }
 
       // Host MACs get a dedicated multi-value widget with a primary picker.
+      // Stored bare (aabbccddeeff) -> displayed as aa:bb:cc:dd:ee:ff.
       if (model === 'host' && key === 'macs') {
+        let stored = Array.isArray(record[key]) ? record[key] : (record[key] ? [record[key]] : []);
         formItems[key] = {
           text: 'MAC Addresses',
           id: `${model}-macs`,
           classes: [],
           textarea: false,
           type: 'maclist',
-          value: Array.isArray(record[key]) ? record[key] : (record[key] ? [record[key]] : [])
+          value: stored.map((m) => {
+            let hex = String(m).replace(/[^0-9a-fA-F]/g, '').toLowerCase();
+            return hex.length === 12 ? hex.match(/.{2}/g).join(':') : m;
+          })
         };
         return;
       }

--- a/api/helpers/form-generator.js
+++ b/api/helpers/form-generator.js
@@ -187,7 +187,7 @@ module.exports = {
                         <div class="input-group-text">
                           <input type="radio" name="__primac" title="Primary MAC"${idx === 0 ? ' checked' : ''}/>
                         </div>
-                        <input type="text" class="form-control" name="macs[]" value="${m}" placeholder="AA:BB:CC:DD:EE:FF" pattern="[0-9A-Fa-f]{2}([:.-]?[0-9A-Fa-f]{2}){5}" title="A MAC address, e.g. AA:BB:CC:DD:EE:FF"/>
+                        <input type="text" class="form-control" name="macs[]" value="${m}" placeholder="aa:bb:cc:dd:ee:ff" pattern="[0-9A-Fa-f]{2}([:.-]?[0-9A-Fa-f]{2}){5}" title="A MAC address, e.g. aa:bb:cc:dd:ee:ff"/>
                         <button type="button" class="btn btn-outline-danger maclist-remove" tabindex="-1">&times;</button>
                       </div>`;
               });

--- a/api/models/Host.js
+++ b/api/models/Host.js
@@ -32,7 +32,9 @@ function normalizeMacs(values, proceed) {
     if (!MAC_HEX.test(hex)) {
       return proceed(new Error(`Invalid MAC address: ${entry}`));
     }
-    let mac = hex.toUpperCase().match(/.{2}/g).join(':');
+    // Stored canonical form: bare lower-case hex, no separators (e.g.
+    // "aabbccddeeff"). Displayed as aa:bb:cc:dd:ee:ff at the view layer.
+    let mac = hex.toLowerCase();
     if (out.indexOf(mac) === -1) {
       out.push(mac);
     }

--- a/assets/fog/fog.maclist.js
+++ b/assets/fog/fog.maclist.js
@@ -9,7 +9,7 @@
         <div class="input-group-text">
           <input type="radio" name="__primac" title="Primary MAC"/>
         </div>
-        <input type="text" class="form-control" name="macs[]" placeholder="AA:BB:CC:DD:EE:FF" pattern="[0-9A-Fa-f]{2}([:.-]?[0-9A-Fa-f]{2}){5}" title="A MAC address, e.g. AA:BB:CC:DD:EE:FF"/>
+        <input type="text" class="form-control" name="macs[]" placeholder="aa:bb:cc:dd:ee:ff" pattern="[0-9A-Fa-f]{2}([:.-]?[0-9A-Fa-f]{2}){5}" title="A MAC address, e.g. aa:bb:cc:dd:ee:ff"/>
         <button type="button" class="btn btn-outline-danger maclist-remove" tabindex="-1">&times;</button>
       </div>`;
   }

--- a/views/pages/partials/list/host.js
+++ b/views/pages/partials/list/host.js
@@ -10,10 +10,12 @@
         data: 'macs',
         orderable: false,
         render: function(data) {
-          if (Array.isArray(data)) {
-            return data.length ? data[0] : '';
+          let mac = Array.isArray(data) ? (data.length ? data[0] : '') : (data || '');
+          if (!mac) {
+            return '';
           }
-          return data || '';
+          let hex = String(mac).replace(/[^0-9a-fA-F]/g, '').toLowerCase();
+          return hex.length === 12 ? hex.match(/.{2}/g).join(':') : mac;
         }
       },
       {data: 'pingstatus'},


### PR DESCRIPTION
Consistent MAC representation per request:

- **Store** canonically as **bare lower-case hex, no separators** (`aabbccddeeff`).
- **Display** as **lower-case 2:2** (`aa:bb:cc:dd:ee:ff`): the host list primary-MAC column and the edit form's MAC inputs format the stored value; inputs re-normalise to bare on save (round-trip stable).
- Lower-cased the placeholder/title hints.

## Verified
`AA:BB:..` and `11-22-..` store as `["aabbccddeeff","112233445566"]`; edit form shows `aa:bb:cc:dd:ee:ff`; saving the colon form stores bare lowercase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)