### PR TITLE
feat(web): edit host associations (selects + checkbox tables)

### DIFF
--- a/api/controllers/general/save.js
+++ b/api/controllers/general/save.js
@@ -43,11 +43,32 @@ module.exports = {
       }
     });
 
+    let attrs = sails.models[model].attributes;
+
+    // Pull out associations: collection (many) associations are applied via
+    // replaceCollection() after the record is saved; singleton (model)
+    // associations are set inline, with "" meaning "none" (null).
+    let collections = {};
+    _.forEach(_.keys(values), (k) => {
+      let attr = attrs[k];
+      if (attr && attr.collection) {
+        let v = values[k];
+        if (!_.isArray(v)) {
+          v = (v === '' || v === null || typeof v === 'undefined') ? [] : [v];
+        }
+        collections[k] = v.filter((x) => x !== '' && x !== null && typeof x !== 'undefined');
+        delete values[k];
+      } else if (attr && attr.model) {
+        if (values[k] === '' || values[k] === null || typeof values[k] === 'undefined') {
+          values[k] = null;
+        }
+      }
+    });
+
     // Normalise boolean attributes only. A checkbox paired with a hidden field
     // submits an array (["false","true"] when checked, "false" when not) -- take
     // the last value, then coerce to a real boolean. Legitimate array fields
     // (e.g. a json `macs` list) are left untouched.
-    let attrs = sails.models[model].attributes;
     _.forEach(values, (v, k) => {
       if (attrs[k] && attrs[k].type === 'boolean') {
         if (_.isArray(v)) {
@@ -77,10 +98,16 @@ module.exports = {
     });
 
     try {
+      let recordId = id;
       if (isUpdate) {
         await sails.models[model].updateOne({ id }).set(values);
       } else {
-        await sails.models[model].create(values);
+        let created = await sails.models[model].create(values).fetch();
+        recordId = created.id;
+      }
+      // Apply many-to-many associations (replace == authoritative set).
+      for (let assoc of _.keys(collections)) {
+        await sails.models[model].replaceCollection(recordId, assoc).members(collections[assoc]);
       }
     } catch (unused) {
       let back = isUpdate ? `/${plural}/edit/${id}` : `/${plural}/create`;

--- a/api/controllers/pages/edit.js
+++ b/api/controllers/pages/edit.js
@@ -29,7 +29,11 @@ module.exports = {
       throw 'notFound';
     }
 
-    let record = await sails.models[model].findOne({ id });
+    let query = sails.models[model].findOne({ id });
+    if (model === 'host') {
+      query = query.populate('image').populate('defaultPrinter').populate('snapins').populate('printers');
+    }
+    let record = await query;
     if (!record) {
       throw 'notFound';
     }
@@ -77,6 +81,36 @@ module.exports = {
       }
       formItems[key] = item;
     });
+
+    // Host associations: single (image, default printer) as selects, multiple
+    // (printers, snapins) as checkbox tables. Groups are intentionally omitted.
+    if (model === 'host') {
+      let [images, printers, snapins] = await Promise.all([
+        sails.models.image.find().sort('name ASC'),
+        sails.models.printer.find().sort('name ASC'),
+        sails.models.snapin.find().sort('name ASC')
+      ]);
+      let imageId = record.image ? record.image.id : null,
+        defPrinterId = record.defaultPrinter ? record.defaultPrinter.id : null,
+        snapinIds = (record.snapins || []).map((s) => s.id),
+        printerIds = (record.printers || []).map((p) => p.id);
+      formItems.image = {
+        text: 'Image', classes: [], textarea: false, type: 'select',
+        options: images.map((i) => ({ value: i.id, label: i.name, selected: i.id === imageId }))
+      };
+      formItems.defaultPrinter = {
+        text: 'Default Printer', classes: [], textarea: false, type: 'select',
+        options: printers.map((p) => ({ value: p.id, label: p.name, selected: p.id === defPrinterId }))
+      };
+      formItems.printers = {
+        text: 'Printers', classes: [], textarea: false, type: 'checktable',
+        options: printers.map((p) => ({ value: p.id, label: p.name, checked: printerIds.indexOf(p.id) !== -1 }))
+      };
+      formItems.snapins = {
+        text: 'Snapins', classes: [], textarea: false, type: 'checktable',
+        options: snapins.map((s) => ({ value: s.id, label: s.name, checked: snapinIds.indexOf(s.id) !== -1 }))
+      };
+    }
 
     let title = model.charAt(0).toUpperCase() + model.slice(1),
       data = {

--- a/api/helpers/form-generator.js
+++ b/api/helpers/form-generator.js
@@ -200,6 +200,52 @@ module.exports = {
               `;
               break;
             }
+            case 'select': {
+              form += `
+                <div class="row mb-3">
+                  <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
+                  <div class="col-sm-10">
+                    <select class="form-control${iClass}"${iId} name="${item}">
+                      <option value="">(none)</option>`;
+              (input.options || []).forEach((o) => {
+                form += `
+                      <option value="${o.value}"${o.selected ? ' selected' : ''}>${o.label}</option>`;
+              });
+              form += `
+                    </select>
+                  </div>
+                </div>
+              `;
+              break;
+            }
+            case 'checktable': {
+              form += `
+                <div class="row mb-3">
+                  <label class="col-sm-2 col-form-label">${input.text}</label>
+                  <div class="col-sm-10">
+                    <div class="border rounded" style="max-height:220px;overflow:auto">
+                      <table class="table table-sm table-hover mb-0">
+                        <tbody>`;
+              if (!(input.options || []).length) {
+                form += `
+                          <tr><td class="text-muted">None available.</td></tr>`;
+              }
+              (input.options || []).forEach((o) => {
+                form += `
+                          <tr>
+                            <td style="width:2.5rem"><input type="checkbox" class="form-check-input" name="${item}[]" value="${o.value}"${o.checked ? ' checked' : ''}/></td>
+                            <td>${o.label}</td>
+                          </tr>`;
+              });
+              form += `
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              `;
+              break;
+            }
             default:
               form += `
                 <div class="row mb-3">


### PR DESCRIPTION
Completes host CRUD with relationships, mirroring 1.x: **singleton** associations use a **selector**, **multi** associations use a **checkbox table**. **Groups intentionally omitted** (to be rethought for fog-node).

- **form-generator**: new `select` (singleton) and `checktable` (multi) field types.
- **pages/edit (host)**: populate current associations; offer **image** + **default printer** as selects and **printers** + **snapins** as checkbox tables (options from each model, current values pre-selected/checked).
- **general/save**: set singleton model associations inline (`""` → null to clear); apply collection associations via `replaceCollection()` after save (create or update).

## Verified (live)
Assigning image/defaultPrinter/printers/snapins via the host edit form persists; re-opening edit reflects the selected/checked state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)