### PR TITLE
feat(web): show save error message on create/edit

### DIFF
--- a/api/controllers/general/save.js
+++ b/api/controllers/general/save.js
@@ -109,9 +109,10 @@ module.exports = {
       for (let assoc of _.keys(collections)) {
         await sails.models[model].replaceCollection(recordId, assoc).members(collections[assoc]);
       }
-    } catch (unused) {
-      let back = isUpdate ? `/${plural}/edit/${id}` : `/${plural}/create`;
-      return res.redirect(`${back}?failed=1`);
+    } catch (err) {
+      let back = isUpdate ? `/${plural}/edit/${id}` : `/${plural}/create`,
+        msg = (err && err.message) ? String(err.message).slice(0, 200) : 'Could not save. Please check your input.';
+      return res.redirect(`${back}?failed=1&msg=${encodeURIComponent(msg)}`);
     }
 
     return res.redirect(`/${plural}`);

--- a/views/pages/create.ejs
+++ b/views/pages/create.ejs
@@ -14,6 +14,9 @@
             <h3 class="card-title"><%= header %></h3>
             <%- partial('../layouts/partials/cardtools.ejs') %>
           </div>
+          <% if (typeof req !== 'undefined' && req.query && req.query.failed) { %>
+          <div class="alert alert-danger m-3"><%= req.query.msg || 'Could not save. Please check your input.' %></div>
+          <% } %>
           <% if (typeof form === 'undefined') form = '' %>
           <%- form %>
         </div>


### PR DESCRIPTION
On a failed create/edit, `general/save` redirects with the error message (`?failed=1&msg=...`) and the create/edit view renders it in an alert (escaped) instead of silently bouncing. A rejected MAC now shows **"Invalid MAC address: <value>"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)