### PR TITLE
fix(auth): logout 500 (passport 0.7 async req.logout)

### DIFF
--- a/api/controllers/auth/logout.js
+++ b/api/controllers/auth/logout.js
@@ -8,8 +8,13 @@ module.exports = {
   fn: async function (inputs) {
     let req = this.req,
       res = this.res;
-    req.logout();
+    // passport >= 0.6 made req.logout() asynchronous -- it requires a callback
+    // and throws (500) if called the old synchronous way. Await it so the action
+    // doesn't return (and send a default response) before the redirect.
+    await new Promise((resolve, reject) => {
+      req.logout((err) => (err ? reject(err) : resolve()));
+    });
     res.clearCookie('jwt');
-    res.redirect('/login');
+    return res.redirect('/login');
   }
 };


### PR DESCRIPTION
`req.logout()` was called synchronously, but passport >= 0.6 made it **async + callback-required**, so `/logout` threw a 500. Now awaits a promisified `req.logout()` (so the action doesn't send a default response before the redirect), clears the jwt cookie, and redirects to /login.

Verified: `/logout` → 302 /login, session cleared, jwt cookie removed, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)