### PR TITLE
feat(web): assign host associations on create (not just edit)

### DIFF
--- a/api/controllers/pages/create/hosts.js
+++ b/api/controllers/pages/create/hosts.js
@@ -54,6 +54,8 @@ module.exports = {
         partialname: false
       },
       partial = path.join(partialPath, `${data.model}.js`);
+    // Offer the host's associations on the create form too (no current values).
+    Object.assign(data.formItems, await sails.helpers.hostAssociationFields(null));
     data.title = `Create New ${data.model.charAt(0).toUpperCase() + data.model.slice(1)}`,
     data.form = await sails.helpers.formGenerator.with({
       model: data.model,

--- a/api/controllers/pages/edit.js
+++ b/api/controllers/pages/edit.js
@@ -85,31 +85,7 @@ module.exports = {
     // Host associations: single (image, default printer) as selects, multiple
     // (printers, snapins) as checkbox tables. Groups are intentionally omitted.
     if (model === 'host') {
-      let [images, printers, snapins] = await Promise.all([
-        sails.models.image.find().sort('name ASC'),
-        sails.models.printer.find().sort('name ASC'),
-        sails.models.snapin.find().sort('name ASC')
-      ]);
-      let imageId = record.image ? record.image.id : null,
-        defPrinterId = record.defaultPrinter ? record.defaultPrinter.id : null,
-        snapinIds = (record.snapins || []).map((s) => s.id),
-        printerIds = (record.printers || []).map((p) => p.id);
-      formItems.image = {
-        text: 'Image', classes: [], textarea: false, type: 'select',
-        options: images.map((i) => ({ value: i.id, label: i.name, selected: i.id === imageId }))
-      };
-      formItems.defaultPrinter = {
-        text: 'Default Printer', classes: [], textarea: false, type: 'select',
-        options: printers.map((p) => ({ value: p.id, label: p.name, selected: p.id === defPrinterId }))
-      };
-      formItems.printers = {
-        text: 'Printers', classes: [], textarea: false, type: 'checktable',
-        options: printers.map((p) => ({ value: p.id, label: p.name, checked: printerIds.indexOf(p.id) !== -1 }))
-      };
-      formItems.snapins = {
-        text: 'Snapins', classes: [], textarea: false, type: 'checktable',
-        options: snapins.map((s) => ({ value: s.id, label: s.name, checked: snapinIds.indexOf(s.id) !== -1 }))
-      };
+      Object.assign(formItems, await sails.helpers.hostAssociationFields(record));
     }
 
     let title = model.charAt(0).toUpperCase() + model.slice(1),

--- a/api/helpers/host-association-fields.js
+++ b/api/helpers/host-association-fields.js
@@ -1,0 +1,49 @@
+module.exports = {
+  friendlyName: 'Host association fields',
+  description: 'Build the form items for a host\'s editable associations (image + default printer as selects, printers + snapins as checkbox tables). Pass the populated host record, or null/none for a new host.',
+  inputs: {
+    record: {
+      type: 'ref',
+      defaultsTo: null
+    }
+  },
+  exits: {
+    success: {
+      outputFriendlyName: 'Association form items'
+    }
+  },
+  fn: async function (inputs) {
+    let record = inputs.record || {};
+
+    let [images, printers, snapins] = await Promise.all([
+      sails.models.image.find().sort('name ASC'),
+      sails.models.printer.find().sort('name ASC'),
+      sails.models.snapin.find().sort('name ASC')
+    ]);
+
+    // Support both populated association objects and raw ids (or absent).
+    let imageId = record.image ? (record.image.id || record.image) : null,
+      defPrinterId = record.defaultPrinter ? (record.defaultPrinter.id || record.defaultPrinter) : null,
+      snapinIds = (record.snapins || []).map((s) => s.id || s),
+      printerIds = (record.printers || []).map((p) => p.id || p);
+
+    return {
+      image: {
+        text: 'Image', classes: [], textarea: false, type: 'select',
+        options: images.map((i) => ({ value: i.id, label: i.name, selected: i.id === imageId }))
+      },
+      defaultPrinter: {
+        text: 'Default Printer', classes: [], textarea: false, type: 'select',
+        options: printers.map((p) => ({ value: p.id, label: p.name, selected: p.id === defPrinterId }))
+      },
+      printers: {
+        text: 'Printers', classes: [], textarea: false, type: 'checktable',
+        options: printers.map((p) => ({ value: p.id, label: p.name, checked: printerIds.indexOf(p.id) !== -1 }))
+      },
+      snapins: {
+        text: 'Snapins', classes: [], textarea: false, type: 'checktable',
+        options: snapins.map((s) => ({ value: s.id, label: s.name, checked: snapinIds.indexOf(s.id) !== -1 }))
+      }
+    };
+  }
+};


### PR DESCRIPTION
The save layer already handled associations on create; this adds them to the **host create form** so image / default printer / printers / snapins can be set at creation time.

- New helper **`hostAssociationFields(record)`**: builds the four association form items (image + default printer selects, printers + snapins checktables) from a populated host record, or empty for a new host.
- Host create controller merges these in (no current values).
- `pages/edit` now uses the same helper (de-dupes the inline block) so create and edit stay in sync.

## Verified
Creating a host with image/defaultPrinter/printers/snapins persists all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)