### PR TITLE
feat(boot): dynamic iPXE boot script endpoint (Phase 2 start)

### DIFF
--- a/api/controllers/boot.js
+++ b/api/controllers/boot.js
@@ -1,0 +1,50 @@
+module.exports = {
+  friendlyName: 'iPXE boot',
+  description: 'Serve a dynamic iPXE boot script. A PXE-booting machine chains here; by default it boots the local disk, and the admin-defined PXE menu entries are offered. (Task-driven auto capture/deploy + FOS kernels are a later, gated step.)',
+  exits: {
+    success: {
+      description: 'iPXE script returned.'
+    }
+  },
+  fn: async function () {
+    let req = this.req,
+      res = this.res,
+      mac = String(req.param('mac') || '').replace(/[^0-9a-fA-F]/g, '').toLowerCase(),
+      host = null;
+
+    // Look up a registered host by MAC (macs stored as bare lower-case hex).
+    if (mac.length === 12) {
+      try {
+        let db = sails.getDatastore(sails.models.host.datastore).manager;
+        host = await db.collection(sails.models.host.tableName).findOne({ macs: mac });
+      } catch (unused) { /* fall through to anonymous menu */ }
+    }
+
+    let menus = await sails.models.pxemenu.find().sort('name ASC'),
+      lines = [];
+
+    lines.push('#!ipxe');
+    lines.push(':start');
+    lines.push('menu FOG Project (fog-node)');
+    lines.push(`item --gap -- Host: ${host ? host.name : (mac || 'unknown')}`);
+    lines.push('item local Boot from local disk');
+    menus.forEach((m, i) => {
+      lines.push(`item pxe${i} ${m.name}`);
+    });
+    lines.push('choose --default local --timeout 5000 selected || goto local');
+    lines.push('goto ${selected}');
+    lines.push('');
+    lines.push(':local');
+    lines.push('echo Booting from local disk');
+    lines.push('sanboot --no-describe --drive 0x80 || exit');
+    menus.forEach((m, i) => {
+      lines.push('');
+      lines.push(`:pxe${i}`);
+      lines.push(m.params || 'echo No parameters configured && sleep 3 && goto start');
+      lines.push('goto start');
+    });
+
+    res.set('Content-Type', 'text/plain');
+    return res.send(lines.join('\n') + '\n');
+  }
+};

--- a/config/policies.js
+++ b/config/policies.js
@@ -50,6 +50,9 @@ module.exports.policies = {
   // Allow API Backend to work
   'api':                   true,
 
+  // iPXE boot script is public (PXE machines have no session)
+  'boot':                  true,
+
   // System info
   'system/info':           true,
   'system/bandwidth':      true,

--- a/config/routes.js
+++ b/config/routes.js
@@ -78,6 +78,10 @@ module.exports.routes = {
   // Search View
   'GET /search':                             {action: 'pages/search'},
 
+  // iPXE boot script (public; hit by PXE-booting machines)
+  'GET /boot.ipxe':                          {action: 'boot'},
+  'GET /boot':                               {action: 'boot'},
+
   // Group Views
   'GET /groups':                             {action: 'pages/list/groups'},
   'GET /groups/create':                      {action: 'pages/create/groups'},


### PR DESCRIPTION
First, simple Phase-2 step: the **boot entry point**.

A PXE-booting machine chains to **`GET /boot.ipxe`** (public, no session). It returns an iPXE script that:
- looks up the host by MAC (`?mac=`, matched against stored bare-hex `macs`),
- offers the admin-defined PXE menu entries (`pxemenu`), and
- defaults to **booting the local disk** (`sanboot`) on a 5s timeout.

**Boot entry point only.** Task-driven auto capture/deploy + the FOS kernels/imaging protocol are the next (gated) step — they need the client/FOS protocol decision and real PXE/FOS hardware to verify.

## Verified
`/boot.ipxe` is public (200, `text/plain`), shows the host name for a known MAC, lists pxemenu entries, includes the local-boot default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)