### PR TITLE
feat(web): grouped tabs on create/edit forms (1.x-style)

### DIFF
--- a/api/controllers/pages/create/hosts.js
+++ b/api/controllers/pages/create/hosts.js
@@ -56,6 +56,7 @@ module.exports = {
       partial = path.join(partialPath, `${data.model}.js`);
     // Offer the host's associations on the create form too (no current values).
     Object.assign(data.formItems, await sails.helpers.associationFields.with({ model: 'host', record: null }));
+    let tabOrder = await sails.helpers.formTabs.with({ model: data.model, formItems: data.formItems });
     data.title = `Create New ${data.model.charAt(0).toUpperCase() + data.model.slice(1)}`,
     data.form = await sails.helpers.formGenerator.with({
       model: data.model,
@@ -64,6 +65,7 @@ module.exports = {
       id: `${data.model}-create`,
       classes: [`${data.model}-create-form`],
       formItems: data.formItems,
+      tabOrder,
       formButtons: data.formButtons
     });
     if (fs.existsSync(partial)) {

--- a/api/controllers/pages/edit.js
+++ b/api/controllers/pages/edit.js
@@ -93,6 +93,7 @@ module.exports = {
         title: `Edit ${title}`,
         partialname: false
       };
+    let tabOrder = await sails.helpers.formTabs.with({ model, formItems });
     data.form = await sails.helpers.formGenerator.with({
       model,
       method: 'post',
@@ -100,6 +101,7 @@ module.exports = {
       id: `${model}-edit`,
       classes: [`${model}-edit-form`],
       formItems,
+      tabOrder,
       formButtons: {
         Cancel: { classes: ['btn-warning', 'float-start'], type: 'submit' },
         Save: { classes: ['btn-success', 'float-end'], type: 'submit' }

--- a/api/helpers/association-fields.js
+++ b/api/helpers/association-fields.js
@@ -46,13 +46,13 @@ module.exports = {
       if (attr.model) {
         let curId = (record[key] && (record[key].id || record[key])) || null;
         out[key] = {
-          text: label, classes: [], textarea: false, type: 'select',
+          text: label, classes: [], textarea: false, type: 'select', tab: 'Associations',
           options: candidates.map((c) => ({ value: c.id, label: labelOf(c), selected: c.id === curId }))
         };
       } else {
         let curIds = (record[key] || []).map((x) => x.id || x);
         out[key] = {
-          text: label, classes: [], textarea: false, type: 'checktable',
+          text: label, classes: [], textarea: false, type: 'checktable', tab: 'Associations',
           options: candidates.map((c) => ({ value: c.id, label: labelOf(c), checked: curIds.indexOf(c.id) !== -1 }))
         };
       }

--- a/api/helpers/form-generator.js
+++ b/api/helpers/form-generator.js
@@ -2,106 +2,45 @@ module.exports = {
   friendlyName: 'Form generator',
   description: 'Generates form information automatically',
   inputs: {
-    model: {
-      friendlyName: 'Model we are building form for',
-      description: 'The form model we are building for',
-      type: 'string',
-      required: true
-    },
-    formItems: {
-      friendlyName: 'Form Items',
-      description: 'What form items to display',
-      type: 'json',
-      required: true
-    },
-    formButtons: {
-      friendlyName: 'Form Buttons',
-      description: 'Form button labels',
-      type: 'json',
-      required: true
-    },
-    formType: {
-      friendlyName: 'Form Type',
-      description: 'The form type we will use',
-      type: 'string',
-      defaultsTo: 'form-horizontal'
-    },
-    method: {
-      friendlyName: 'Form Method',
-      description: 'The form method',
-      type: 'string',
-      defaultsTo: 'post'
-    },
-    action: {
-      friendlyName: "Form Action",
-      description: 'The form action',
-      type: 'string'
-    },
-    id: {
-      friendlyName: 'DOM id',
-      description: 'The form DOM id to use',
-      type: 'string'
-    },
-    classes: {
-      friendlyName: 'Additional Classes',
-      description: 'The additional classes to use',
+    model: { type: 'string', required: true },
+    formItems: { type: 'json', required: true },
+    formButtons: { type: 'json', required: true },
+    formType: { type: 'string', defaultsTo: 'form-horizontal' },
+    method: { type: 'string', defaultsTo: 'post' },
+    action: { type: 'string' },
+    id: { type: 'string' },
+    classes: { type: 'json', defaultsTo: [] },
+    tabOrder: {
+      description: 'Optional ordered list of tab names. When set (and >1 tab has items) the fields are grouped into Bootstrap tabs by each item\'s `tab` property.',
       type: 'json',
       defaultsTo: []
     }
   },
   exits: {
-    success: {
-      description: 'All done.',
-    },
+    success: { description: 'All done.' }
   },
   fn: async function (inputs) {
     let model = inputs.model,
       formType = inputs.formType,
-      method = inputs.method,
+      method = (inputs.method || 'post').toLowerCase() === 'get' ? 'get' : 'post',
       action = inputs.action,
       id = inputs.id,
       classes = inputs.classes,
       formItems = inputs.formItems,
       formButtons = inputs.formButtons,
-      formo = false,
-      formi = false,
-      form = `<form `;
-    switch (method.toLowerCase()) {
-      case 'get':
-        method = 'get';
-        break;
-      default:
-        method = 'post';
-    }
-    form += ` method="${method}"`;
-    form += ` action="${action}"`;
-    if (id) {
-      form += ` id="${id}"`;
-    }
-    form += ` class="${formType}`;
-    if (classes.length) {
-      form += ` ${classes.join(' ')}`;
-    }
-    form += `">
-      <div class="card-body">`
-    for (item in formItems) {
-      input = formItems[item];
-      obj = sails.models[model].attributes[item];
-      let iChecked = '',
-        iId = '',
-        iFor = '',
-        iClass = '',
-        iValue = '',
-        iPlaceholder = '',
-        iMaxlength = '',
-        iMinlength = '',
-        iRegex = '',
-        iName = ` name="${item}"`;
+      tabOrder = inputs.tabOrder || [];
+
+    // Render a single form item to its HTML string.
+    function renderField(item, input, obj) {
+      let iChecked = '', iId = '', iFor = '', iClass = '', iValue = '',
+        iPlaceholder = '', iMaxlength = '', iMinlength = '', iRegex = '',
+        iName = ` name="${item}"`,
+        field = '';
       if (input.id) {
         iFor = ` for="${input.id}"`;
         iId = ` id="${input.id}"`;
       }
-      if (input.classes.length > 0) {
+      if (input.classes && input.classes.length > 0) {
         iClass = ` ${input.classes.join(' ')}`;
       }
       if (input.value) {
@@ -110,162 +49,166 @@ module.exports = {
       if (input.placeholder) {
         iPlaceholder = ` placeholder="${input.placeholder}"`;
       }
-      if (input.validations || (typeof obj !== 'undefined' && obj.validations)) {
-        if (input.validations) {
-          if (input.validations.maxLength) {
-            iMaxlength = ` maxlength="${input.validations.maxLength}"`;
-          }
-          if (input.validations.minLength) {
-            iMinlength = ` minlength="${input.validations.minLength}"`;
-          }
-          if (input.validations.regex) {
-            iRegex = ` regex="${input.validations.regex}"`;
-          }
-        }
-        if (typeof obj !== 'undefined' && obj.validations) {
-          if (obj.validations.maxLength) {
-            iMaxlength = ` maxlength="${obj.validations.maxLength}"`;
-          }
-          if (obj.validations.minLength) {
-            iMinlength = ` minlength="${obj.validations.minLength}"`;
-          }
-          if (obj.validations.regex) {
-            iRegex = ` regex="${obj.validations.regex}"`;
-          }
-        }
+      let v = input.validations || (obj && obj.validations);
+      if (v) {
+        if (v.maxLength) { iMaxlength = ` maxlength="${v.maxLength}"`; }
+        if (v.minLength) { iMinlength = ` minlength="${v.minLength}"`; }
+        if (v.regex) { iRegex = ` regex="${v.regex}"`; }
       }
-      switch (input.textarea) {
-        case true:
-          form += `
+      if (input.textarea === true) {
+        return `
             <div class="row mb-3">
               <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
               <div class="col-sm-10">
                 <textarea${iId} class="form-control${iClass}"${iPlaceholder}${iName}>${iValue}</textarea>
               </div>
-            </div>
-          `;
-          break;
-        default:
-          switch (input.type) {
-            case 'checkbox':
-              if (input.checked) {
-                iChecked = ` checked`;
-              }
-              form += `
-                <div class="row mb-3">
-                  <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
-                  <div class="col-sm-10">
-                    <div class="form-check mt-2">
-                      <input type="hidden"${iName} value="false"/>
-                      <input type="checkbox" class="form-check-input${iClass}"${iId}${iName} value="true"${iChecked}/>
+            </div>`;
+      }
+      switch (input.type) {
+        case 'checkbox':
+          if (input.checked) { iChecked = ` checked`; }
+          return `
+            <div class="row mb-3">
+              <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
+              <div class="col-sm-10">
+                <div class="form-check mt-2">
+                  <input type="hidden"${iName} value="false"/>
+                  <input type="checkbox" class="form-check-input${iClass}"${iId}${iName} value="true"${iChecked}/>
+                </div>
+              </div>
+            </div>`;
+        case 'maclist': {
+          let macs = Array.isArray(input.value) ? input.value : (input.value ? [input.value] : []);
+          if (!macs.length) { macs = ['']; }
+          field += `
+            <div class="row mb-3">
+              <label class="col-sm-2 col-form-label">${input.text}</label>
+              <div class="col-sm-10">
+                <div data-maclist>`;
+          macs.forEach((m, idx) => {
+            field += `
+                  <div class="input-group mb-1 maclist-row">
+                    <div class="input-group-text">
+                      <input type="radio" name="__primac" title="Primary MAC"${idx === 0 ? ' checked' : ''}/>
                     </div>
-                  </div>
+                    <input type="text" class="form-control" name="macs[]" value="${m}" placeholder="aa:bb:cc:dd:ee:ff" pattern="[0-9A-Fa-f]{2}([:.-]?[0-9A-Fa-f]{2}){5}" title="A MAC address, e.g. aa:bb:cc:dd:ee:ff"/>
+                    <button type="button" class="btn btn-outline-danger maclist-remove" tabindex="-1">&times;</button>
+                  </div>`;
+          });
+          field += `
+                  <button type="button" class="btn btn-sm btn-secondary maclist-add">+ Add MAC</button>
                 </div>
-              `;
-              break;
-            case 'radio':
-              // To do create loop and make this check an array required element
-              if (input.value.toLowerCase() === input.selected.toLowerCase()) {
-                iChecked=` selected`;
-              }
-              form += `
-                <div class="row mb-3">
-                </div>
-              `
-              break;
-            case 'maclist': {
-              let macs = Array.isArray(input.value) ? input.value : (input.value ? [input.value] : []);
-              if (!macs.length) { macs = ['']; }
-              form += `
-                <div class="row mb-3">
-                  <label class="col-sm-2 col-form-label">${input.text}</label>
-                  <div class="col-sm-10">
-                    <div data-maclist>`;
-              macs.forEach((m, idx) => {
-                form += `
-                      <div class="input-group mb-1 maclist-row">
-                        <div class="input-group-text">
-                          <input type="radio" name="__primac" title="Primary MAC"${idx === 0 ? ' checked' : ''}/>
-                        </div>
-                        <input type="text" class="form-control" name="macs[]" value="${m}" placeholder="aa:bb:cc:dd:ee:ff" pattern="[0-9A-Fa-f]{2}([:.-]?[0-9A-Fa-f]{2}){5}" title="A MAC address, e.g. aa:bb:cc:dd:ee:ff"/>
-                        <button type="button" class="btn btn-outline-danger maclist-remove" tabindex="-1">&times;</button>
-                      </div>`;
-              });
-              form += `
-                      <button type="button" class="btn btn-sm btn-secondary maclist-add">+ Add MAC</button>
-                    </div>
-                    <small class="form-text text-muted">Select the radio of the primary MAC.</small>
-                  </div>
-                </div>
-              `;
-              break;
-            }
-            case 'select': {
-              form += `
-                <div class="row mb-3">
-                  <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
-                  <div class="col-sm-10">
-                    <select class="form-control${iClass}"${iId} name="${item}">
-                      <option value="">(none)</option>`;
-              (input.options || []).forEach((o) => {
-                form += `
-                      <option value="${o.value}"${o.selected ? ' selected' : ''}>${o.label}</option>`;
-              });
-              form += `
-                    </select>
-                  </div>
-                </div>
-              `;
-              break;
-            }
-            case 'checktable': {
-              form += `
-                <div class="row mb-3">
-                  <label class="col-sm-2 col-form-label">${input.text}</label>
-                  <div class="col-sm-10">
-                    <div class="border rounded" style="max-height:220px;overflow:auto">
-                      <table class="table table-sm table-hover mb-0">
-                        <tbody>`;
-              if (!(input.options || []).length) {
-                form += `
-                          <tr><td class="text-muted">None available.</td></tr>`;
-              }
-              (input.options || []).forEach((o) => {
-                form += `
-                          <tr>
-                            <td style="width:2.5rem"><input type="checkbox" class="form-check-input" name="${item}[]" value="${o.value}"${o.checked ? ' checked' : ''}/></td>
-                            <td>${o.label}</td>
-                          </tr>`;
-              });
-              form += `
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </div>
-              `;
-              break;
-            }
-            default:
-              form += `
-                <div class="row mb-3">
-                  <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
-                  <div class="col-sm-10">
-                    <input type="${input.type}"${iId} class="form-control${iClass}"${iName}${iPlaceholder} value="${iValue}"${iMaxlength}${iMinlength}${iRegex}${iChecked}/>
-                  </div>
-                </div>
-              `;
+                <small class="form-text text-muted">Select the radio of the primary MAC.</small>
+              </div>
+            </div>`;
+          return field;
+        }
+        case 'select': {
+          field += `
+            <div class="row mb-3">
+              <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
+              <div class="col-sm-10">
+                <select class="form-control${iClass}"${iId} name="${item}">
+                  <option value="">(none)</option>`;
+          (input.options || []).forEach((o) => {
+            field += `
+                  <option value="${o.value}"${o.selected ? ' selected' : ''}>${o.label}</option>`;
+          });
+          field += `
+                </select>
+              </div>
+            </div>`;
+          return field;
+        }
+        case 'checktable': {
+          field += `
+            <div class="row mb-3">
+              <label class="col-sm-2 col-form-label">${input.text}</label>
+              <div class="col-sm-10">
+                <div class="border rounded" style="max-height:220px;overflow:auto">
+                  <table class="table table-sm table-hover mb-0">
+                    <tbody>`;
+          if (!(input.options || []).length) {
+            field += `
+                      <tr><td class="text-muted">None available.</td></tr>`;
           }
+          (input.options || []).forEach((o) => {
+            field += `
+                      <tr>
+                        <td style="width:2.5rem"><input type="checkbox" class="form-check-input" name="${item}[]" value="${o.value}"${o.checked ? ' checked' : ''}/></td>
+                        <td>${o.label}</td>
+                      </tr>`;
+          });
+          field += `
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>`;
+          return field;
+        }
+        default:
+          return `
+            <div class="row mb-3">
+              <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
+              <div class="col-sm-10">
+                <input type="${input.type}"${iId} class="form-control${iClass}"${iName}${iPlaceholder} value="${iValue}"${iMaxlength}${iMinlength}${iRegex}${iChecked}/>
+              </div>
+            </div>`;
       }
     }
+
+    // Group rendered fields into tab buckets (by each item's `tab`, default General).
+    let buckets = {}, seen = [];
+    for (let item in formItems) {
+      let input = formItems[item],
+        obj = sails.models[model].attributes[item],
+        tab = input.tab || 'General';
+      if (!buckets[tab]) { buckets[tab] = ''; seen.push(tab); }
+      buckets[tab] += renderField(item, input, obj);
+    }
+
+    // Decide tab order: requested order first (only tabs that have content),
+    // then any remaining tabs in first-seen order.
+    let tabs = tabOrder.filter((t) => buckets[t]);
+    seen.forEach((t) => { if (tabs.indexOf(t) === -1) { tabs.push(t); } });
+
+    let slug = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    let form = `<form method="${method}" action="${action}"`;
+    if (id) { form += ` id="${id}"`; }
+    form += ` class="${formType}`;
+    if (classes.length) { form += ` ${classes.join(' ')}`; }
+    form += `">
+      <div class="card-body">`;
+
+    if (tabs.length > 1) {
+      form += `
+        <ul class="nav nav-tabs" role="tablist">`;
+      tabs.forEach((t, idx) => {
+        form += `
+          <li class="nav-item"><a class="nav-link${idx === 0 ? ' active' : ''}" data-bs-toggle="tab" href="#tab-${slug(t)}" role="tab">${t}</a></li>`;
+      });
+      form += `
+        </ul>
+        <div class="tab-content pt-3">`;
+      tabs.forEach((t, idx) => {
+        form += `
+          <div class="tab-pane fade${idx === 0 ? ' show active' : ''}" id="tab-${slug(t)}" role="tabpanel">${buckets[t]}
+          </div>`;
+      });
+      form += `
+        </div>`;
+    } else {
+      form += (tabs.length ? buckets[tabs[0]] : '');
+    }
+
     form += `
       </div>
       <div class="card-footer">`;
-    for (button in formButtons) {
-      btn = formButtons[button];
-      form +=`
-        <button type="${btn.type}" class="btn${btn.classes.length ? ` ${btn.classes.join(' ')}` : ''}"${btn.id ? ` id="${btn.id}"` : ''}>${button}</button>
-      `;
+    for (let button in formButtons) {
+      let btn = formButtons[button];
+      form += `
+        <button type="${btn.type}" class="btn${btn.classes && btn.classes.length ? ` ${btn.classes.join(' ')}` : ''}"${btn.id ? ` id="${btn.id}"` : ''}>${button}</button>`;
     }
     form += `
       </div>

--- a/api/helpers/form-tabs.js
+++ b/api/helpers/form-tabs.js
@@ -1,0 +1,46 @@
+// Field -> tab mapping for the Host form (mirrors FOG 1.x's grouped tabs).
+const HOST_MAP = {
+  name: 'General', description: 'General', ip: 'General', building: 'General',
+  deployed: 'General', createdBy: 'General', guid: 'General', image: 'General',
+  macs: 'MAC Addresses',
+  kernel: 'Boot', kernelArgs: 'Boot', kernelDevice: 'Boot', init: 'Boot',
+  biosexit: 'Boot', efiexit: 'Boot',
+  useAD: 'Active Directory', ADDomain: 'Active Directory', ADOU: 'Active Directory',
+  ADUser: 'Active Directory', ADPass: 'Active Directory', ADPassLegacy: 'Active Directory',
+  printerLevel: 'Printers', defaultPrinter: 'Printers', printers: 'Printers',
+  snapins: 'Snapins',
+  productKey: 'Service', pending: 'Service', pubKey: 'Service', secToken: 'Service',
+  secTime: 'Service', pingstatus: 'Service', enforce: 'Service', token: 'Service',
+  tokenlock: 'Service'
+};
+const HOST_ORDER = ['General', 'MAC Addresses', 'Boot', 'Active Directory', 'Printers', 'Snapins', 'Service'];
+
+module.exports = {
+  friendlyName: 'Form tabs',
+  description: 'Assign each form item to a tab (in place) and return the tab order for the form generator.',
+  inputs: {
+    model: { type: 'string', required: true },
+    formItems: { type: 'ref', required: true }
+  },
+  exits: {
+    success: { outputFriendlyName: 'Tab order' }
+  },
+  fn: async function (inputs) {
+    let model = inputs.model,
+      formItems = inputs.formItems || {};
+
+    if (model === 'host') {
+      Object.keys(formItems).forEach((k) => {
+        formItems[k].tab = HOST_MAP[k] || 'General';
+      });
+      return HOST_ORDER;
+    }
+
+    // Generic: scalar fields -> General; association fields already carry
+    // tab: 'Associations' (set by the associationFields helper).
+    Object.keys(formItems).forEach((k) => {
+      if (!formItems[k].tab) { formItems[k].tab = 'General'; }
+    });
+    return ['General', 'Associations'];
+  }
+};


### PR DESCRIPTION
Groups form fields into Bootstrap tabs so big forms read like FOG 1.x.

- **form-generator**: per-field rendering extracted to `renderField()`; fields are bucketed by each item's `tab` and rendered as **nav-tabs + tab-panes** when there's >1 tab (otherwise flat). New `tabOrder` input.
- **form-tabs helper**: host gets the detailed map — **General · MAC Addresses · Boot · Active Directory · Printers · Snapins · Service**; other models get **General · Associations**. Empty tabs auto-omitted.
- `associationFields` tags association items with the `Associations` tab.

## Verified
Host edit → 7 tabs; host create → populated subset (General/MAC/Printers/Snapins); snapin edit → General+Associations; pxemenu → flat. Submitting through tabs still saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)