### PR TITLE
fix(plugins): track the plugin loader + bundled wol (gitignore was too broad)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,12 @@ config.json
 ################################################
 # FOG specific
 ################################################
-plugins
+# Runtime-installed plugins live under /plugins/ and are not committed -- except
+# the bundled reference plugins (e.g. wol). The plugin LOADER is core
+# (api/hooks/plugins) and must stay tracked, so don't use a bare `plugins`
+# pattern (it would match api/hooks/plugins too).
+/plugins/*
+!/plugins/wol/
 images
 
 ################################################

--- a/api/hooks/plugins/index.js
+++ b/api/hooks/plugins/index.js
@@ -1,0 +1,52 @@
+/**
+ * plugins hook
+ *
+ * @description :: Lightweight, Sails-1.x-native plugin loader for fog-node.
+ *   Reads plugins.json (`enabled`) and loads each plugin from `plugins/<name>/`.
+ *   A plugin module may contribute:
+ *     - `routes`    : { 'VERB /path': (req, res) => {} }  bound after app routes
+ *     - `menuItems` : [ ... ]  appended to the sidebar menu
+ *   This is the modern replacement for fog-too's PluginService + the old
+ *   sails-util-mvcsloader (which targeted Sails 0.12). Imaging stays in core;
+ *   management features (wol, printers, snapins, AD, ...) live as plugins.
+ *
+ * @docs :: https://sailsjs.com/docs/concepts/extending-sails/hooks
+ */
+const path = require('path'),
+  fs = require('fs');
+
+module.exports = function definePluginsHook(sails) {
+  let appRoot = path.join(__dirname, '..', '..', '..'),
+    routes = {},
+    menuItems = [],
+    loaded = [];
+
+  try {
+    let cfg = JSON.parse(fs.readFileSync(path.join(appRoot, 'plugins.json'), 'utf8'));
+    (cfg.enabled || []).forEach((name) => {
+      let dir = path.join(appRoot, 'plugins', name);
+      if (!fs.existsSync(dir)) { return; }
+      let plugin = require(dir);
+      if (plugin.routes) { Object.assign(routes, plugin.routes); }
+      if (plugin.menuItems) { menuItems = menuItems.concat(plugin.menuItems); }
+      loaded.push(plugin.name || name);
+    });
+  } catch (err) {
+    // Surfaced in initialize() once the logger is available.
+    routes.__error = err;
+  }
+
+  return {
+    routes: { after: routes.__error ? {} : routes },
+    initialize: async function () {
+      if (routes.__error) {
+        sails.log.error(`Plugins hook failed to load plugins.json: ${routes.__error}`);
+        return;
+      }
+      if (menuItems.length && sails.config.globals && Array.isArray(sails.config.globals.menuItems)) {
+        sails.config.globals.menuItems = sails.config.globals.menuItems.concat(menuItems);
+      }
+      sails.log.info(`Plugins loaded: ${loaded.length ? loaded.join(', ') : 'none'}`);
+    }
+  };
+};

--- a/plugins/wol/index.js
+++ b/plugins/wol/index.js
@@ -1,0 +1,46 @@
+/**
+ * wol plugin
+ *
+ * Wake-on-LAN: sends a magic packet to a host's MAC address(es). Demonstrates
+ * the fog-node plugin contract (a management feature added as a plugin, not in
+ * the imaging core). Enabled via plugins.json.
+ */
+const dgram = require('dgram');
+
+function sendMagicPacket(mac) {
+  return new Promise((resolve, reject) => {
+    let hex = String(mac).replace(/[^0-9a-fA-F]/g, '');
+    if (hex.length !== 12) { return reject(new Error(`Invalid MAC: ${mac}`)); }
+    let macBuf = Buffer.from(hex, 'hex'),
+      parts = [Buffer.alloc(6, 0xff)];
+    for (let i = 0; i < 16; i++) { parts.push(macBuf); }
+    let packet = Buffer.concat(parts), // 6 + 16*6 = 102 bytes
+      socket = dgram.createSocket('udp4');
+    socket.once('error', (err) => { socket.close(); reject(err); });
+    socket.bind(() => {
+      socket.setBroadcast(true);
+      socket.send(packet, 0, packet.length, 9, '255.255.255.255', (err) => {
+        socket.close();
+        return err ? reject(err) : resolve();
+      });
+    });
+  });
+}
+
+module.exports = {
+  name: 'wol',
+  routes: {
+    'POST /api/v1/host/:id/wol': async function (req, res) {
+      // Plugin routes aren't covered by the core action policies, so guard here.
+      if (!req.user) { return res.forbidden(); }
+      let host = await sails.models.host.findOne({ id: req.param('id') });
+      if (!host) { return res.notFound(); }
+      let macs = Array.isArray(host.macs) ? host.macs : (host.macs ? [host.macs] : []),
+        sent = [], failed = [];
+      for (let mac of macs) {
+        try { await sendMagicPacket(mac); sent.push(mac); } catch (err) { failed.push(mac); }
+      }
+      return res.json({ host: host.name, sent, failed });
+    }
+  }
+};


### PR DESCRIPTION
A bare `plugins` ignore matched both `/plugins/` and `api/hooks/plugins`, so the prior PR only landed the doc — the loader hook and wol plugin were skipped.

- `.gitignore`: `/plugins/*` + `!/plugins/wol/` — core loader + bundled wol tracked; other runtime-installed plugins stay ignored.
- Adds `api/hooks/plugins/index.js` (loader) and `plugins/wol/` (reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)