### PR TITLE
docs: clarify AD plugin + define imaging core (crux)

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -25,7 +25,11 @@ plugins live, and the open issues that actually relate to the rewrite. (Captured
 | `tftp-server` | (no split repo found — built-in or not yet extracted) |
 | (snapins) | fog-plugin-snapin |
 | (printing) | fog-plugin-print ("Printer plugin for FOG 2.0") / fog-plugin-printer ("fog-too plugin … printer management") |
-| (AD) | fog-plugin-activedirectory |
+| (admin auth) | fog-plugin-activedirectory — **AD authentication for logging into fog-node**, NOT the host AD-join fields. |
+
+> The Host's `useAD`/`ADDomain`/… fields are a *post-deploy* "join the imaged
+> machine to the domain" concern (done by FOS/fog-client) — unrelated to the
+> fog-plugin-activedirectory admin-auth plugin.
 
 Mechanism: `sails-util-micro-apps`. All plugin repos currently have **0 open
 issues**.

--- a/docs/imaging.md
+++ b/docs/imaging.md
@@ -3,6 +3,20 @@
 Status: **design / in progress.** The boot entry point (`GET /boot.ipxe`) ships;
 the capture/deploy engine below is the plan, to be built in verifiable steps.
 
+## The imaging core (the crux)
+
+fog-node core is just the imaging essentials; everything else is a plugin:
+
+1. **iPXE boot generation + forwarding** — generate the per-host iPXE script and
+   forward/chain the machine to the right next stage (FOS + kernel on the storage
+   node hosting its image). `GET /boot.ipxe` is the start of this.
+2. **Storage node** — who is hosting the images (and serves/receives the bytes).
+3. **Hosts** — the machines being imaged (+ Images, + Tasks/Workflow).
+
+Note: a host's `useAD`/`ADDomain`/… are a *post-deploy domain-join* concern
+(handled by FOS/fog-client), **not** the `fog-plugin-activedirectory` plugin
+(which is AD authentication for logging into fog-node).
+
 ## Context (from the sibling repos)
 
 - **fog-too** — the earlier "FOG 2.0" Sails app; **fog-node** is the current


### PR DESCRIPTION
- AD plugin = authentication for logging into fog-node, **not** the host AD-join fields (post-deploy domain join via FOS/fog-client).
- Records the imaging core: **iPXE boot generation + forwarding · storage node (image host) · hosts** (+images/tasks); everything else is a plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)