### PR TITLE
feat(plugins): host extension points + AD as a plugin (ADR 0001 keystone)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ config.json
 # pattern (it would match api/hooks/plugins too).
 /plugins/*
 !/plugins/wol/
+!/plugins/ad/
 images
 
 ################################################

--- a/api/controllers/general/destroy.js
+++ b/api/controllers/general/destroy.js
@@ -10,6 +10,13 @@ module.exports = {
     if (!Array.isArray(id)) {
       id = [id];
     }
-    return await sails.models[model].destroy({id}).fetch();
+    let destroyed = await sails.models[model].destroy({id}).fetch();
+    // Cascade: let plugins remove their host-linked records.
+    if (model === 'host' && sails.plugins && sails.plugins.hostDestroy) {
+      for (let hid of id) {
+        await sails.plugins.hostDestroy(hid);
+      }
+    }
+    return destroyed;
   }
 };

--- a/api/controllers/general/save.js
+++ b/api/controllers/general/save.js
@@ -109,6 +109,10 @@ module.exports = {
       for (let assoc of _.keys(collections)) {
         await sails.models[model].replaceCollection(recordId, assoc).members(collections[assoc]);
       }
+      // Let plugins persist their slice of a host save (their own collections).
+      if (model === 'host' && sails.plugins && sails.plugins.hostSave) {
+        await sails.plugins.hostSave(recordId, req.allParams());
+      }
     } catch (err) {
       let back = isUpdate ? `/${plural}/edit/${id}` : `/${plural}/create`,
         msg = (err && err.message) ? String(err.message).slice(0, 200) : 'Could not save. Please check your input.';

--- a/api/controllers/pages/create/hosts.js
+++ b/api/controllers/pages/create/hosts.js
@@ -56,6 +56,10 @@ module.exports = {
       partial = path.join(partialPath, `${data.model}.js`);
     // Offer the host's associations on the create form too (no current values).
     Object.assign(data.formItems, await sails.helpers.associationFields.with({ model: 'host', record: null }));
+    // Plugin-contributed host fields (e.g. the AD plugin's tab).
+    if (sails.plugins && sails.plugins.hostForm) {
+      Object.assign(data.formItems, await sails.plugins.hostForm(null));
+    }
     let tabOrder = await sails.helpers.formTabs.with({ model: data.model, formItems: data.formItems });
     data.title = `Create New ${data.model.charAt(0).toUpperCase() + data.model.slice(1)}`,
     data.form = await sails.helpers.formGenerator.with({

--- a/api/controllers/pages/edit.js
+++ b/api/controllers/pages/edit.js
@@ -86,6 +86,11 @@ module.exports = {
       Object.assign(formItems, await sails.helpers.associationFields.with({ model, record }));
     }
 
+    // Plugin-contributed host fields (e.g. the AD plugin's tab).
+    if (model === 'host' && sails.plugins && sails.plugins.hostForm) {
+      Object.assign(formItems, await sails.plugins.hostForm(record));
+    }
+
     let title = model.charAt(0).toUpperCase() + model.slice(1),
       data = {
         model,

--- a/api/helpers/form-tabs.js
+++ b/api/helpers/form-tabs.js
@@ -5,8 +5,7 @@ const HOST_MAP = {
   macs: 'MAC Addresses',
   kernel: 'Boot', kernelArgs: 'Boot', kernelDevice: 'Boot', init: 'Boot',
   biosexit: 'Boot', efiexit: 'Boot',
-  useAD: 'Active Directory', ADDomain: 'Active Directory', ADOU: 'Active Directory',
-  ADUser: 'Active Directory', ADPass: 'Active Directory', ADPassLegacy: 'Active Directory',
+  // (Active Directory fields now come from the `ad` plugin, which sets their tab.)
   printerLevel: 'Printers', defaultPrinter: 'Printers', printers: 'Printers',
   snapins: 'Snapins',
   productKey: 'Service', pending: 'Service', pubKey: 'Service', secToken: 'Service',
@@ -31,7 +30,9 @@ module.exports = {
 
     if (model === 'host') {
       Object.keys(formItems).forEach((k) => {
-        formItems[k].tab = HOST_MAP[k] || 'General';
+        // Preserve a tab a plugin already set (e.g. the AD plugin's fields);
+        // otherwise use the core host map.
+        formItems[k].tab = formItems[k].tab || HOST_MAP[k] || 'General';
       });
       return HOST_ORDER;
     }

--- a/api/hooks/plugins/index.js
+++ b/api/hooks/plugins/index.js
@@ -6,6 +6,12 @@
  *   A plugin module may contribute:
  *     - `routes`    : { 'VERB /path': (req, res) => {} }  bound after app routes
  *     - `menuItems` : [ ... ]  appended to the sidebar menu
+ *     - `extends.host` : { form(record), save(hostId, params), destroy(hostId) }
+ *         form    -> returns extra formItems for the host create/edit form,
+ *                    populated from the plugin's OWN collection (never the host).
+ *         save    -> persists the plugin's namespaced fields (e.g. params.ad)
+ *                    to the plugin's collection, keyed by host id.
+ *         destroy -> removes the plugin's host-linked record (cascade).
  *   This is the modern replacement for fog-too's PluginService + the old
  *   sails-util-mvcsloader (which targeted Sails 0.12). Imaging stays in core;
  *   management features (wol, printers, snapins, AD, ...) live as plugins.
@@ -19,7 +25,9 @@ module.exports = function definePluginsHook(sails) {
   let appRoot = path.join(__dirname, '..', '..', '..'),
     routes = {},
     menuItems = [],
-    loaded = [];
+    hostExtensions = [],
+    loaded = [],
+    loadError = null;
 
   try {
     let cfg = JSON.parse(fs.readFileSync(path.join(appRoot, 'plugins.json'), 'utf8'));
@@ -29,23 +37,50 @@ module.exports = function definePluginsHook(sails) {
       let plugin = require(dir);
       if (plugin.routes) { Object.assign(routes, plugin.routes); }
       if (plugin.menuItems) { menuItems = menuItems.concat(plugin.menuItems); }
+      if (plugin.extends && plugin.extends.host) {
+        hostExtensions.push(Object.assign({ name: plugin.name || name }, plugin.extends.host));
+      }
       loaded.push(plugin.name || name);
     });
   } catch (err) {
-    // Surfaced in initialize() once the logger is available.
-    routes.__error = err;
+    loadError = err;
   }
 
   return {
-    routes: { after: routes.__error ? {} : routes },
+    routes: { after: loadError ? {} : routes },
     initialize: async function () {
-      if (routes.__error) {
-        sails.log.error(`Plugins hook failed to load plugins.json: ${routes.__error}`);
-        return;
-      }
-      if (menuItems.length && sails.config.globals && Array.isArray(sails.config.globals.menuItems)) {
+      if (loadError) {
+        sails.log.error(`Plugins hook failed to load plugins.json: ${loadError}`);
+      } else if (menuItems.length && sails.config.globals && Array.isArray(sails.config.globals.menuItems)) {
         sails.config.globals.menuItems = sails.config.globals.menuItems.concat(menuItems);
       }
+
+      // Expose plugin extension dispatch to core controllers.
+      sails.plugins = {
+        loaded: loadError ? [] : loaded,
+        hostExtensions: loadError ? [] : hostExtensions,
+        // Merge every plugin's host form contributions into one formItems object.
+        hostForm: async function (record) {
+          let out = {};
+          for (let ext of hostExtensions) {
+            if (ext.form) { Object.assign(out, (await ext.form(record)) || {}); }
+          }
+          return out;
+        },
+        // Let each plugin persist its slice of a host save.
+        hostSave: async function (hostId, params) {
+          for (let ext of hostExtensions) {
+            if (ext.save) { await ext.save(hostId, params); }
+          }
+        },
+        // Cascade: let each plugin remove its host-linked record.
+        hostDestroy: async function (hostId) {
+          for (let ext of hostExtensions) {
+            if (ext.destroy) { await ext.destroy(hostId); }
+          }
+        }
+      };
+
       sails.log.info(`Plugins loaded: ${loaded.length ? loaded.join(', ') : 'none'}`);
     }
   };

--- a/api/models/Host.js
+++ b/api/models/Host.js
@@ -81,25 +81,9 @@ module.exports = {
     createdBy: {
       type: 'string'
     },
-    useAD: {
-      type: 'boolean',
-      defaultsTo: false
-    },
-    ADDomain: {
-      type: 'string'
-    },
-    ADOU: {
-      type: 'string'
-    },
-    ADUser: {
-      type: 'string'
-    },
-    ADPass: {
-      type: 'string'
-    },
-    ADPassLegacy: {
-      type: 'string'
-    },
+    // Active Directory domain-join fields moved OUT to the `ad` plugin
+    // (plugins/ad) -- it owns its own collection + contributes the AD tab via
+    // the host:form/host:save/host:destroy hooks. See docs/adr/0001.
     productKey: {
       type: 'string'
     },

--- a/plugins.json
+++ b/plugins.json
@@ -1,6 +1,7 @@
 {
   "enabled": [
-    "wol"
+    "wol",
+    "ad"
   ],
   "disabled": [
     "tftp-server",

--- a/plugins/ad/index.js
+++ b/plugins/ad/index.js
@@ -1,0 +1,71 @@
+/**
+ * ad plugin
+ *
+ * Host Active Directory domain-join (a POST-DEPLOY concern handled by FOS/
+ * fog-client) -- the reference example of a plugin that extends a core entity
+ * WITHOUT touching the core model. It owns its own mongo collection
+ * (`plugin_ad`, keyed by host id) and contributes an "Active Directory" tab to
+ * the host form via the host:form / host:save / host:destroy hooks.
+ *
+ * (Distinct from fog-plugin-activedirectory, which is admin login auth.)
+ */
+const COLLECTION = 'plugin_ad';
+
+function coll() {
+  return sails.getDatastore(sails.models.host.datastore).manager.collection(COLLECTION);
+}
+
+function toBool(v) {
+  if (Array.isArray(v)) { v = v[v.length - 1]; } // hidden+checkbox pair
+  return v === true || v === 'true' || v === 'on' || v === '1';
+}
+
+const AD = 'Active Directory';
+
+module.exports = {
+  name: 'ad',
+  extends: {
+    host: {
+      // Build the "Active Directory" tab, populated from this plugin's record.
+      form: async function (record) {
+        let doc = (record && record.id) ? await coll().findOne({ host: String(record.id) }) : null;
+        doc = doc || {};
+        return {
+          'ad[useAD]': { text: 'Join Domain', type: 'checkbox', classes: [], textarea: false, tab: AD, checked: !!doc.useAD },
+          'ad[ADDomain]': { text: 'Domain', type: 'text', classes: [], textarea: false, tab: AD, value: doc.ADDomain || '' },
+          'ad[ADOU]': { text: 'Organizational Unit', type: 'text', classes: [], textarea: false, tab: AD, value: doc.ADOU || '' },
+          'ad[ADUser]': { text: 'Domain User', type: 'text', classes: [], textarea: false, tab: AD, value: doc.ADUser || '' },
+          'ad[ADPass]': { text: 'Domain Password', type: 'password', classes: [], textarea: false, tab: AD, value: doc.ADPass || '' },
+          'ad[ADPassLegacy]': { text: 'Legacy Password', type: 'text', classes: [], textarea: false, tab: AD, value: doc.ADPassLegacy || '' }
+        };
+      },
+
+      // Persist this plugin's slice (params.ad) into its own collection.
+      save: async function (hostId, params) {
+        if (!params || !params.ad) { return; }
+        let ad = params.ad;
+        await coll().updateOne(
+          { host: String(hostId) },
+          {
+            $set: {
+              host: String(hostId),
+              useAD: toBool(ad.useAD),
+              ADDomain: ad.ADDomain || '',
+              ADOU: ad.ADOU || '',
+              ADUser: ad.ADUser || '',
+              ADPass: ad.ADPass || '',
+              ADPassLegacy: ad.ADPassLegacy || '',
+              updatedAt: Date.now()
+            }
+          },
+          { upsert: true }
+        );
+      },
+
+      // Cascade cleanup when the host is deleted.
+      destroy: async function (hostId) {
+        await coll().deleteOne({ host: String(hostId) });
+      }
+    }
+  }
+};


### PR DESCRIPTION
The keystone of the plugin architecture (ADR 0001): a plugin extends a core entity **without touching the core model**, owning its own collection.

- **Extension dispatch**: the plugins hook exposes `sails.plugins.{hostForm,hostSave,hostDestroy}` from each plugin's `extends.host.{form,save,destroy}`.
- **Core wiring**: `pages/edit` + `pages/create/hosts` merge plugin host-form fields; `general/save` calls `hostSave` after persisting the host; `general/destroy` cascades `hostDestroy`.
- **AD extracted**: removed AD domain-join from the core `Host` model + form-tabs; added `plugins/ad` — owns the `plugin_ad` mongo collection (keyed by host id), contributes an **Active Directory** tab via `host:form`, persists its namespaced `ad[…]` fields via `host:save`, cascades on `host:destroy`.
- `form-tabs` preserves plugin-set tabs (AD tab shows only when the plugin contributes; empty tabs auto-omitted).

## Verified
AD tab renders from the plugin; host doc has **no** AD fields; data round-trips via `plugin_ad`; host delete cascades; disabling the plugin drops the tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)