### PR TITLE
feat(host): scored hardware-fingerprint identity (#198)

### DIFF
--- a/api/controllers/boot.js
+++ b/api/controllers/boot.js
@@ -12,13 +12,19 @@ module.exports = {
       mac = String(req.param('mac') || '').replace(/[^0-9a-fA-F]/g, '').toLowerCase(),
       host = null;
 
-    // Look up a registered host by MAC (macs stored as bare lower-case hex).
-    if (mac.length === 12) {
-      try {
-        let db = sails.getDatastore(sails.models.host.datastore).manager;
-        host = await db.collection(sails.models.host.tableName).findOne({ macs: mac });
-      } catch (unused) { /* fall through to anonymous menu */ }
-    }
+    // Identify the host by its hardware fingerprint (issue #198), not MAC alone:
+    // iPXE passes the SMBIOS values (${uuid}/${serial}/${asset}/${mac}).
+    try {
+      let match = await sails.helpers.identifyHost.with({
+        fingerprint: {
+          guid: req.param('uuid'),
+          serial: req.param('serial'),
+          asset: req.param('asset'),
+          mac: mac
+        }
+      });
+      if (match) { host = match.host; }
+    } catch (unused) { /* fall through to anonymous menu */ }
 
     let menus = await sails.models.pxemenu.find().sort('name ASC'),
       lines = [];

--- a/api/helpers/form-tabs.js
+++ b/api/helpers/form-tabs.js
@@ -1,7 +1,8 @@
 // Field -> tab mapping for the Host form (mirrors FOG 1.x's grouped tabs).
 const HOST_MAP = {
   name: 'General', description: 'General', ip: 'General', building: 'General',
-  deployed: 'General', createdBy: 'General', guid: 'General', image: 'General',
+  deployed: 'General', createdBy: 'General', image: 'General',
+  guid: 'Identity', serial: 'Identity', asset: 'Identity',
   macs: 'MAC Addresses',
   kernel: 'Boot', kernelArgs: 'Boot', kernelDevice: 'Boot', init: 'Boot',
   biosexit: 'Boot', efiexit: 'Boot',
@@ -12,7 +13,7 @@ const HOST_MAP = {
   secTime: 'Service', pingstatus: 'Service', enforce: 'Service', token: 'Service',
   tokenlock: 'Service'
 };
-const HOST_ORDER = ['General', 'MAC Addresses', 'Boot', 'Active Directory', 'Printers', 'Snapins', 'Service'];
+const HOST_ORDER = ['General', 'MAC Addresses', 'Identity', 'Boot', 'Active Directory', 'Printers', 'Snapins', 'Service'];
 
 module.exports = {
   friendlyName: 'Form tabs',

--- a/api/helpers/identify-host.js
+++ b/api/helpers/identify-host.js
@@ -1,0 +1,72 @@
+/**
+ * identifyHost helper (issue #198)
+ *
+ * Identify a host by the scored *makeup of the physical machine* rather than by
+ * MAC alone. Given a fingerprint presented at boot/check-in (the SMBIOS values
+ * iPXE exposes natively), score every candidate host across the signals and
+ * return the best confident match -- so a NIC swap (MAC changes) or a board swap
+ * (UUID changes) still resolves to the right host.
+ *
+ * Returns the matched host's native mongo doc (with `_id`, `name`, ...) and the
+ * score, or null when nothing clears the threshold.
+ */
+
+// Per-signal weights. UUID is the strongest single identifier; a bare MAC match
+// alone still clears the threshold (preserves classic FOG behaviour).
+const WEIGHTS = { guid: 100, serial: 50, asset: 30, mac: 40 };
+const THRESHOLD = 40;
+
+function norm(v) {
+  return (typeof v === 'string') ? v.trim().toLowerCase() : '';
+}
+function normMac(v) {
+  let hex = String(v == null ? '' : v).replace(/[\s.:-]/g, '').toLowerCase();
+  return /^[0-9a-f]{12}$/.test(hex) ? hex : '';
+}
+
+module.exports = {
+  friendlyName: 'Identify host',
+  description: 'Find the best-matching host for a presented hardware fingerprint (issue #198).',
+  inputs: {
+    fingerprint: {
+      type: {},
+      required: true,
+      description: 'SMBIOS-ish signals: { guid|uuid, serial, asset, mac|macs }.'
+    }
+  },
+  exits: {
+    success: { outputFriendlyName: 'Match', description: 'null, or { host, score, signals }.' }
+  },
+  fn: async function (inputs) {
+    let fp = inputs.fingerprint || {},
+      guid = norm(fp.guid || fp.uuid),
+      serial = norm(fp.serial),
+      asset = norm(fp.asset),
+      macsIn = fp.macs || fp.mac || [],
+      macs = (Array.isArray(macsIn) ? macsIn : [macsIn]).map(normMac).filter(Boolean);
+
+    // Build a query that fetches only the hosts sharing at least one signal.
+    let or = [];
+    if (guid) { or.push({ guid }); }
+    if (serial) { or.push({ serial }); }
+    if (asset) { or.push({ asset }); }
+    if (macs.length) { or.push({ macs: { $in: macs } }); }
+    if (!or.length) { return null; }
+
+    let coll = sails.getDatastore(sails.models.host.datastore).manager.collection(sails.models.host.tableName),
+      candidates = await coll.find({ $or: or }).toArray();
+
+    let best = null;
+    for (let c of candidates) {
+      let score = 0, signals = [];
+      if (guid && norm(c.guid) === guid) { score += WEIGHTS.guid; signals.push('guid'); }
+      if (serial && norm(c.serial) === serial) { score += WEIGHTS.serial; signals.push('serial'); }
+      if (asset && norm(c.asset) === asset) { score += WEIGHTS.asset; signals.push('asset'); }
+      let chostMacs = Array.isArray(c.macs) ? c.macs : [];
+      if (macs.some((m) => chostMacs.indexOf(m) !== -1)) { score += WEIGHTS.mac; signals.push('mac'); }
+      if (!best || score > best.score) { best = { host: c, score, signals }; }
+    }
+
+    return (best && best.score >= THRESHOLD) ? best : null;
+  }
+};

--- a/api/models/Host.js
+++ b/api/models/Host.js
@@ -43,6 +43,16 @@ function normalizeMacs(values, proceed) {
   return proceed();
 }
 
+// Canonicalise the fingerprint fields so identity matching is stable: trim, and
+// lower-case the guid/serial/asset (SMBIOS values vary in case across firmware).
+function normalizeIdentity(values) {
+  ['guid', 'serial', 'asset'].forEach((k) => {
+    if (Object.prototype.hasOwnProperty.call(values, k) && typeof values[k] === 'string') {
+      values[k] = values[k].trim().toLowerCase();
+    }
+  });
+}
+
 module.exports = {
   attributes: {
     name: {
@@ -64,6 +74,15 @@ module.exports = {
     },
     macs: {
       type: 'json'
+    },
+    // --- Hardware fingerprint (issue #198): a host is identified by the scored
+    //     makeup of the physical machine, not by MAC alone. iPXE exposes these
+    //     SMBIOS values natively. `guid` is the SMBIOS product UUID. ---
+    serial: {
+      type: 'string'
+    },
+    asset: {
+      type: 'string'
     },
     // --- FOG 1.x `hosts` scalar fields (friendly names; snake_case
     //     security fields normalised to camelCase) ---
@@ -163,9 +182,11 @@ module.exports = {
     }
   },
   beforeCreate: function(values, proceed) {
+    normalizeIdentity(values);
     return normalizeMacs(values, proceed);
   },
   beforeUpdate: function(values, proceed) {
+    normalizeIdentity(values);
     return normalizeMacs(values, proceed);
   }
 };


### PR DESCRIPTION
A host is identified by the scored **makeup of the physical machine**, not by MAC alone — so a NIC swap (MAC changes) or board swap (UUID changes) still resolves to the right host. This is the fog-node take on FOG 1.6 issue #198.

- **Host**: adds `serial` + `asset` (with the existing `guid` = SMBIOS UUID); `normalizeIdentity()` trims + lowercases them so matching is stable across firmware case differences.
- **`helpers/identifyHost`**: weighted scorer — guid 100 / serial 50 / asset 30 / mac 40, threshold 40 (a bare MAC still identifies). Queries only candidates sharing a signal; returns the best match or null.
- **`boot.ipxe`**: identifies via the scorer using the SMBIOS values iPXE passes (`${uuid}/${serial}/${asset}/${mac}`), replacing the MAC-only lookup.
- **form-tabs**: a new **Identity** host tab.

## Verified
Match by MAC; by UUID with a *wrong* MAC (NIC swap); by serial alone. Asset-only (below threshold) and unknown machines correctly don't match. Identity fields stored normalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)