### PR TITLE
feat(host): tags + bulk host-list actions (groups replacement, part 1)

### DIFF
--- a/api/controllers/host/bulk.js
+++ b/api/controllers/host/bulk.js
@@ -1,0 +1,60 @@
+/**
+ * host/bulk
+ *
+ * Apply tag/image changes to many hosts at once -- the "push config to a set of
+ * hosts" half of what 1.x groups did, driven by host-list selection instead of a
+ * group entity (see docs/adr/0001). Accepts { id:[...], addTags, removeTags,
+ * image } where `image` is an image name or id ('' clears it).
+ */
+module.exports = {
+  friendlyName: 'Bulk host update',
+  description: 'Apply tag/image changes to many selected hosts.',
+  fn: async function () {
+    let req = this.req,
+      res = this.res,
+      p = req.allParams(),
+      perms = req.user && req.user.permissions && req.user.permissions.stock && req.user.permissions.stock.host;
+
+    if (!perms || !perms.update) { return res.forbidden(); }
+
+    let ids = Array.isArray(p.id) ? p.id : (p.id ? [p.id] : []);
+    if (!ids.length) { return res.badRequest({ error: 'No hosts selected.' }); }
+
+    let toArr = (v) => (Array.isArray(v) ? v : (v ? [v] : [])).map((x) => String(x).trim()).filter(Boolean),
+      addTags = toArr(p.addTags),
+      removeTags = toArr(p.removeTags).map((t) => t.toLowerCase());
+
+    // Resolve a requested image by name or id; '' (or null) clears it.
+    let imageSet; // undefined => leave image alone
+    if (Object.prototype.hasOwnProperty.call(p, 'image')) {
+      if (p.image === '' || p.image === null) {
+        imageSet = null;
+      } else {
+        let img = await sails.models.image.findOne({ name: p.image });
+        if (!img) { try { img = await sails.models.image.findOne({ id: p.image }); } catch (unused) { /* not an id */ } }
+        if (!img) { return res.badRequest({ error: `Image not found: ${p.image}` }); }
+        imageSet = img.id;
+      }
+    }
+
+    let hosts = await sails.models.host.find({ id: ids }),
+      updated = 0;
+    for (let h of hosts) {
+      let set = {};
+      if (addTags.length || removeTags.length) {
+        let tags = Array.isArray(h.tags) ? h.tags.slice() : [];
+        tags = tags.filter((t) => removeTags.indexOf(String(t).toLowerCase()) === -1);
+        for (let t of addTags) {
+          if (!tags.some((x) => String(x).toLowerCase() === t.toLowerCase())) { tags.push(t); }
+        }
+        set.tags = tags;
+      }
+      if (imageSet !== undefined) { set.image = imageSet; }
+      if (Object.keys(set).length) {
+        await sails.models.host.updateOne({ id: h.id }).set(set);
+        updated++;
+      }
+    }
+    return res.json({ updated });
+  }
+};

--- a/api/controllers/pages/create/hosts.js
+++ b/api/controllers/pages/create/hosts.js
@@ -39,6 +39,14 @@ module.exports = {
             id: 'hostdescription',
             classes: [],
             placeholder: 'Some general description'
+          },
+          tags: {
+            textarea: false,
+            text: 'Tags',
+            type: 'text',
+            id: 'hosttags',
+            classes: [],
+            placeholder: 'lab-a, win11, 3rd-floor'
           }
         },
         formButtons: {

--- a/api/controllers/pages/edit.js
+++ b/api/controllers/pages/edit.js
@@ -60,6 +60,17 @@ module.exports = {
         return;
       }
 
+      // Tags: a comma-separated text field over the json array.
+      if (model === 'host' && key === 'tags') {
+        let stored = Array.isArray(record[key]) ? record[key] : [];
+        formItems[key] = {
+          text: 'Tags', id: `${model}-tags`, classes: [], textarea: false,
+          type: 'text', placeholder: 'lab-a, win11, 3rd-floor',
+          value: stored.join(', ')
+        };
+        return;
+      }
+
       let label = key.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase()),
         val = record[key],
         item = { text: label, id: `${model}-${key}`, classes: [], textarea: false };

--- a/api/controllers/pages/list/hosts.js
+++ b/api/controllers/pages/list/hosts.js
@@ -26,6 +26,7 @@ module.exports = {
           'Ping Status',
           'Last Deployed',
           'Assigned Image',
+          'Tags',
           'Description'
         ],
         model: 'host',

--- a/api/helpers/form-tabs.js
+++ b/api/helpers/form-tabs.js
@@ -1,7 +1,7 @@
 // Field -> tab mapping for the Host form (mirrors FOG 1.x's grouped tabs).
 const HOST_MAP = {
   name: 'General', description: 'General', ip: 'General', building: 'General',
-  deployed: 'General', createdBy: 'General', image: 'General',
+  deployed: 'General', createdBy: 'General', image: 'General', tags: 'General',
   guid: 'Identity', serial: 'Identity', asset: 'Identity',
   macs: 'MAC Addresses',
   kernel: 'Boot', kernelArgs: 'Boot', kernelDevice: 'Boot', init: 'Boot',

--- a/api/models/Host.js
+++ b/api/models/Host.js
@@ -43,6 +43,30 @@ function normalizeMacs(values, proceed) {
   return proceed();
 }
 
+// Normalise the `tags` json array: accept a comma/newline-separated string or an
+// array, trim, drop blanks, and de-dupe (case-insensitively, keeping first form).
+function normalizeTags(values) {
+  if (!Object.prototype.hasOwnProperty.call(values, 'tags')) {
+    return;
+  }
+  let raw = values.tags;
+  if (typeof raw === 'string') {
+    raw = raw.split(/[\n,]+/);
+  }
+  if (!Array.isArray(raw)) {
+    raw = (raw === null || typeof raw === 'undefined') ? [] : [raw];
+  }
+  let out = [], seen = {};
+  for (let entry of raw) {
+    if (entry === null || typeof entry === 'undefined') { continue; }
+    let tag = String(entry).trim();
+    if (tag === '') { continue; }
+    let key = tag.toLowerCase();
+    if (!seen[key]) { seen[key] = true; out.push(tag); }
+  }
+  values.tags = out;
+}
+
 // Canonicalise the fingerprint fields so identity matching is stable: trim, and
 // lower-case the guid/serial/asset (SMBIOS values vary in case across firmware).
 function normalizeIdentity(values) {
@@ -73,6 +97,12 @@ module.exports = {
       type: 'string'
     },
     macs: {
+      type: 'json'
+    },
+    // Free-form labels for organising/filtering hosts. These replace 1.x groups
+    // for the "named set + group-by" use case (see docs/adr/0001). Stored as a
+    // de-duped string array.
+    tags: {
       type: 'json'
     },
     // --- Hardware fingerprint (issue #198): a host is identified by the scored
@@ -183,10 +213,12 @@ module.exports = {
   },
   beforeCreate: function(values, proceed) {
     normalizeIdentity(values);
+    normalizeTags(values);
     return normalizeMacs(values, proceed);
   },
   beforeUpdate: function(values, proceed) {
     normalizeIdentity(values);
+    normalizeTags(values);
     return normalizeMacs(values, proceed);
   }
 };

--- a/assets/fog/fog.common.js
+++ b/assets/fog/fog.common.js
@@ -88,6 +88,13 @@ $.fn.registerTable = function(onSelect, opts) {
     processing: true
   });
 
+  // Per-list extra toolbar buttons (e.g. host bulk actions) appended to the
+  // shared Select/Edit/Delete set.
+  if (Array.isArray(opts.extraButtons)) {
+    opts.buttons = opts.buttons.concat(opts.extraButtons);
+    delete opts.extraButtons;
+  }
+
   let table = $(this).DataTable(opts);
 
   if (onSelect !== undefined && typeof onSelect === 'functin') {

--- a/config/policies.js
+++ b/config/policies.js
@@ -27,6 +27,9 @@ module.exports.policies = {
   'group/register':        ['isLoggedIn','isAuthenticated', 'group/register'],
   'group/unregister':      ['isLoggedIn','isAuthenticated', 'group/unregister'],
 
+  // Host bulk actions (checks host update permission itself)
+  'host/bulk':             ['isLoggedIn','isAuthenticated'],
+
   // Image Policies
   'image/capture':         ['isLoggedIn','isAuthenticated', 'image/capture'],
   'image/deploy':          ['isLoggedIn','isAuthenticated', 'image/deploy'],

--- a/config/routes.js
+++ b/config/routes.js
@@ -52,6 +52,9 @@ module.exports.routes = {
   // User API
   'GET /api/v1/user/me':                     {action: 'user/listme'},
 
+  // Host API
+  'POST /api/v1/host/bulk':                  {action: 'host/bulk'},
+
   // Global search (must precede the :model routes).
   'GET /api/v1/search':                      {action: 'search'},
 

--- a/views/pages/partials/list/host.js
+++ b/views/pages/partials/list/host.js
@@ -1,8 +1,53 @@
 (function($) {
   let path = $(location).attr('pathname').replace(/s$/,'');
+  function selectedIds(dt) {
+    return dt.rows({selected: true}).data().toArray().map((r) => r.id).filter(Boolean);
+  }
+  function bulk(dt, body) {
+    $.ajax({
+      url: '/api/v1/host/bulk',
+      type: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify(body),
+      complete: function() { dt.ajax.reload(); }
+    });
+  }
   $('#listtable').registerTable(undefined, {
     order: [
       [0, 'asc']
+    ],
+    // Bulk "push to a set of hosts" actions (the 1.x group replacement).
+    extraButtons: [
+      {
+        text: '<i class="fa fa-tag"></i> Add Tag',
+        action: function(e, dt) {
+          let ids = selectedIds(dt);
+          if (!ids.length) { window.alert('Select one or more hosts.'); return; }
+          let tag = window.prompt(`Tag to ADD to ${ids.length} host(s):`);
+          if (!tag) { return; }
+          bulk(dt, {id: ids, addTags: [tag]});
+        }
+      },
+      {
+        text: '<i class="fa fa-tag"></i> Remove Tag',
+        action: function(e, dt) {
+          let ids = selectedIds(dt);
+          if (!ids.length) { window.alert('Select one or more hosts.'); return; }
+          let tag = window.prompt(`Tag to REMOVE from ${ids.length} host(s):`);
+          if (!tag) { return; }
+          bulk(dt, {id: ids, removeTags: [tag]});
+        }
+      },
+      {
+        text: '<i class="fa fa-desktop"></i> Set Image',
+        action: function(e, dt) {
+          let ids = selectedIds(dt);
+          if (!ids.length) { window.alert('Select one or more hosts.'); return; }
+          let name = window.prompt(`Image NAME to assign to ${ids.length} host(s) (blank to clear):`);
+          if (name === null) { return; }
+          bulk(dt, {id: ids, image: name});
+        }
+      }
     ],
     columns: [
       {data: 'name'},
@@ -25,6 +70,13 @@
         orderable: false,
         render: function(data) {
           return (data && data.name) ? data.name : '';
+        }
+      },
+      {
+        data: 'tags',
+        orderable: false,
+        render: function(data) {
+          return Array.isArray(data) ? data.join(', ') : (data || '');
         }
       },
       {data: 'description'}


### PR DESCRIPTION
Replaces what 1.x groups actually do — a named set of hosts + pushing config to that set — with **host tags** + **host-list bulk actions** (per ADR 0001), no Group entity.

- **Host.tags** (json) + `normalizeTags` (comma/newline string or array → trimmed, de-duped case-insensitively).
- **Forms**: tags on host create + generic edit (comma-separated); **Tags** list column.
- **Bulk**: `registerTable` gains `extraButtons`; host list adds **Add Tag / Remove Tag / Set Image**. `POST /api/v1/host/bulk` applies `addTags`/`removeTags` (case-insensitive) + `image` (by name or id; `''` clears) across selected hosts, checking host update perm.

Bulk **task scheduling** (the other group use) is deferred — it needs the paused imaging engine. This part covers tags + bulk config-push.

## Verified
Tags round-trip + de-dupe; edit form shows them; bulk add/remove/set-image; unknown image → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)