### PR TITLE
docs(adr): groups replaced by tags + bulk actions (built)

### DIFF
--- a/docs/adr/0001-imaging-core-and-plugin-model.md
+++ b/docs/adr/0001-imaging-core-and-plugin-model.md
@@ -106,6 +106,10 @@ Two unrelated things, do not conflate:
 - **Host fingerprint identity** (`helpers/identifyHost`): weighted scorer
   guid 100 / serial 50 / asset 30 / mac 40, threshold 40; wired into
   `boot.ipxe`. (PR #49)
+- **Groups removed** → host `tags` + bulk host-list actions (Add/Remove Tag,
+  Set Image via `POST /api/v1/host/bulk`). The Group entity and its
+  associations are deleted. (PR #51, #52). Bulk *task* scheduling is deferred to
+  the imaging engine.
 
 ## Open questions
 


### PR DESCRIPTION
Records in ADR 0001 that the Group entity is removed and replaced by host tags + bulk host-list actions (#51, #52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)