### PR TITLE
feat(plugins): plugins can contribute Waterline models + permissions

### DIFF
--- a/api/hooks/plugins/index.js
+++ b/api/hooks/plugins/index.js
@@ -26,6 +26,8 @@ module.exports = function definePluginsHook(sails) {
     routes = {},
     menuItems = [],
     hostExtensions = [],
+    models = {},
+    permissions = {},
     loaded = [],
     loadError = null;
 
@@ -37,6 +39,8 @@ module.exports = function definePluginsHook(sails) {
       let plugin = require(dir);
       if (plugin.routes) { Object.assign(routes, plugin.routes); }
       if (plugin.menuItems) { menuItems = menuItems.concat(plugin.menuItems); }
+      if (plugin.models) { Object.assign(models, plugin.models); }
+      if (plugin.permissions) { Object.assign(permissions, plugin.permissions); }
       if (plugin.extends && plugin.extends.host) {
         hostExtensions.push(Object.assign({ name: plugin.name || name }, plugin.extends.host));
       }
@@ -48,6 +52,28 @@ module.exports = function definePluginsHook(sails) {
 
   return {
     routes: { after: loadError ? {} : routes },
+    // Contribute plugin Waterline models into the ORM (merged after api/models,
+    // before Waterline initializes) so plugin entities get the full generic CRUD.
+    configure: function () {
+      if (loadError) { return; }
+      if (Object.keys(models).length) {
+        sails.config.orm = sails.config.orm || {};
+        sails.config.orm.moduleDefinitions = sails.config.orm.moduleDefinitions || {};
+        sails.config.orm.moduleDefinitions.models = Object.assign(
+          sails.config.orm.moduleDefinitions.models || {},
+          models
+        );
+      }
+      // Contribute plugin entity permissions so roles can be granted them
+      // (admin roles auto-receive every config permission).
+      if (Object.keys(permissions).length) {
+        sails.config.permissions = sails.config.permissions || {};
+        sails.config.permissions.stock = Object.assign(
+          sails.config.permissions.stock || {},
+          permissions
+        );
+      }
+    },
     initialize: async function () {
       if (loadError) {
         sails.log.error(`Plugins hook failed to load plugins.json: ${loadError}`);

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -28,17 +28,41 @@ module.exports = {
     'POST /api/v1/host/:id/wol': async function (req, res) { /* … */ }
   },
   // Optional: appended to the sidebar menu (config/globals.js menuItems shape).
-  menuItems: []
+  menuItems: [],
+
+  // Optional: contribute full Waterline MODELS. Merged into the ORM
+  // (sails.config.orm.moduleDefinitions.models) before Waterline initializes, so
+  // the entity gets the entire generic CRUD for free: /api/v1/<identity>,
+  // datatables, the generic edit page, global search, associations. Keyed by
+  // identity; config/models.js defaults (datastore, id, timestamps) are applied.
+  models: {
+    snapin: { identity: 'snapin', globalId: 'Snapin', attributes: { /* … */ } }
+  },
+
+  // Optional: contribute permissions for those entities. Merged into
+  // sails.config.permissions.stock; admin roles auto-receive them, non-admin
+  // roles can be granted them. Without this the CRUD policies 403.
+  permissions: {
+    snapin: { create: false, read: false, update: false, destroy: false }
+  },
+
+  // Optional: extend a core entity's form/data without touching the core model.
+  // form(record) -> extra formItems (from the plugin's own collection);
+  // save(hostId, params) -> persist the plugin's slice; destroy(hostId) -> cascade.
+  extends: {
+    host: { form: async (record) => ({}), save: async (id, p) => {}, destroy: async (id) => {} }
+  }
 };
 ```
 
-The shipped **`wol`** plugin (`plugins/wol/`) is the reference example: it adds
-`POST /api/v1/host/:id/wol` to send a Wake-on-LAN magic packet to a host's MACs.
+The shipped **`wol`** plugin (`plugins/wol/`) is the route-only reference; **`ad`**
+(`plugins/ad/`) is the `extends.host` reference (its own `plugin_ad` collection +
+an injected "Active Directory" tab).
 
 ## Status / roadmap
 
 - ✅ Loader + `wol` proof.
-- Next: extension points so a plugin can also add a **model**, its own **pages**,
-  and contribute to a **core entity's form** (e.g. a "Snapins" tab on the host
-  edit page) — needed before extracting today's in-core Snapins/Printers/AD out
-  into `fog-plugin-snapin` / `fog-plugin-print` / `fog-plugin-activedirectory`.
+- ✅ `extends.host` form/save/destroy extension points (AD plugin).
+- ✅ Plugins contribute **models** + **permissions** → full generic CRUD.
+- Next: extract today's in-core Snapins/Printers into `fog-plugin-snapin` /
+  `fog-plugin-print` using `models` (catalog CRUD) + `extends.host` (assignment).


### PR DESCRIPTION
Unblocks moving full entities (snapins, printers) into plugins. A plugin can now declare **`models`** and **`permissions`**, and the entity gets the *entire existing generic CRUD* — no native reimplementation.

- `configure()` merges `plugin.models` into `sails.config.orm.moduleDefinitions.models` (Sails' documented merge point — after `api/models`, before Waterline init) and `plugin.permissions` into `sails.config.permissions.stock` (admin roles auto-receive via `deepMap`).
- So `/api/v1/<identity>`, datatables, the generic edit page, global search, and associations all work for plugin models; `config/models.js` defaults (datastore, id, timestamps) apply.

## Verified
Throwaway plugin model: 403 without the contributed permission, then **create → 200** (id + timestamps), list works, mongo collection created — confirming both the model and permission paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)