### PR TITLE
feat(plugins): plugins contribute entities to global search

### DIFF
--- a/api/helpers/global-search.js
+++ b/api/helpers/global-search.js
@@ -44,6 +44,11 @@ module.exports = {
       { model: 'user', label: 'Users', fields: ['username', 'email', 'displayName'] }
     ];
 
+    // Append entities contributed by enabled plugins (snapins, printers, ...).
+    if (sails.plugins && Array.isArray(sails.plugins.search)) {
+      searchConfig = searchConfig.concat(sails.plugins.search);
+    }
+
     for (let cfg of searchConfig) {
       let Model = sails.models[cfg.model];
       if (!Model) { continue; }

--- a/api/hooks/plugins/index.js
+++ b/api/hooks/plugins/index.js
@@ -28,6 +28,7 @@ module.exports = function definePluginsHook(sails) {
     hostExtensions = [],
     models = {},
     permissions = {},
+    search = [],
     loaded = [],
     loadError = null;
 
@@ -41,6 +42,7 @@ module.exports = function definePluginsHook(sails) {
       if (plugin.menuItems) { menuItems = menuItems.concat(plugin.menuItems); }
       if (plugin.models) { Object.assign(models, plugin.models); }
       if (plugin.permissions) { Object.assign(permissions, plugin.permissions); }
+      if (plugin.search) { search = search.concat(plugin.search); }
       if (plugin.extends && plugin.extends.host) {
         hostExtensions.push(Object.assign({ name: plugin.name || name }, plugin.extends.host));
       }
@@ -85,6 +87,9 @@ module.exports = function definePluginsHook(sails) {
       sails.plugins = {
         loaded: loadError ? [] : loaded,
         hostExtensions: loadError ? [] : hostExtensions,
+        // Search entities contributed by plugins (model/label/fields), appended
+        // to core global search only while the plugin is enabled.
+        search: loadError ? [] : search,
         // Merge every plugin's host form contributions into one formItems object.
         hostForm: async function (record) {
           let out = {};

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -46,6 +46,12 @@ module.exports = {
     snapin: { create: false, read: false, update: false, destroy: false }
   },
 
+  // Optional: add the entity to global search (only while the plugin is enabled,
+  // so disabling it can't break search). model/label/fields.
+  search: [
+    { model: 'snapin', label: 'Snapins', fields: ['name', 'description', 'file'] }
+  ],
+
   // Optional: extend a core entity's form/data without touching the core model.
   // form(record) -> extra formItems (from the plugin's own collection);
   // save(hostId, params) -> persist the plugin's slice; destroy(hostId) -> cascade.

--- a/plugins/printer/index.js
+++ b/plugins/printer/index.js
@@ -49,6 +49,10 @@ module.exports = {
     printer: { create: false, read: false, update: false, destroy: false }
   },
 
+  search: [
+    { model: 'printer', label: 'Printers', fields: ['name', 'description', 'printerModel', 'ip'] }
+  ],
+
   menuItems: [
     {
       text: 'Printer',

--- a/plugins/snapin/index.js
+++ b/plugins/snapin/index.js
@@ -57,6 +57,10 @@ module.exports = {
     snapin: { create: false, read: false, update: false, destroy: false }
   },
 
+  search: [
+    { model: 'snapin', label: 'Snapins', fields: ['name', 'description', 'file'] }
+  ],
+
   menuItems: [
     {
       text: 'Snapin',


### PR DESCRIPTION
Restores snapins/printers to global search **without re-coupling core to plugin entities**: a plugin declares `search: [{ model, label, fields }]`, collected into `sails.plugins.search` and appended to the core search config **only while the plugin is enabled**.

- plugins hook collects `plugin.search` → `sails.plugins.search`.
- `global-search` appends it to the core `searchConfig`.
- snapin + printer plugins declare their search entity; documented in `docs/plugins.md`.

## Verified
Plugins enabled → snapin/printer appear in `/api/v1/search`; disabled → search still works (200) and they're absent (removable-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)