### PR TITLE
feat(ui): Create-new modal on list views + infinite-scroll DataTables

### DIFF
--- a/api/controllers/general/save.js
+++ b/api/controllers/general/save.js
@@ -114,13 +114,20 @@ module.exports = {
         await sails.plugins.hostSave(recordId, req.allParams());
       }
     } catch (err) {
-      let back = isUpdate ? `/${plural}/edit/${id}` : `/${plural}/create`,
-        msg = (err && err.message) ? String(err.message).slice(0, 200) : 'Could not save. Please check your input.';
+      let msg = (err && err.message) ? String(err.message).slice(0, 200) : 'Could not save. Please check your input.';
+      // Modal/AJAX submit -> JSON; full-page submit -> redirect back with the message.
+      if (req.wantsJSON) {
+        return res.status(400).json({ ok: false, message: msg });
+      }
+      let back = isUpdate ? `/${plural}/edit/${id}` : `/${plural}/create`;
       return res.redirect(`${back}?failed=1&msg=${encodeURIComponent(msg)}`);
     }
 
-    // Stay on the record's edit page with a success flag (instead of bouncing to
-    // the list).
+    // Modal/AJAX submit -> JSON ({ok,id}); full-page submit -> stay on the
+    // record's edit page with a success flag.
+    if (req.wantsJSON) {
+      return res.json({ ok: true, id: recordId });
+    }
     return res.redirect(`/${plural}/edit/${recordId}?saved=1`);
   }
 };

--- a/assets/fog/fog.common.js
+++ b/assets/fog/fog.common.js
@@ -6,16 +6,18 @@ $.fn.registerTable = function(onSelect, opts) {
   opts = opts || {};
   opts = _.defaults(opts, {
     paging: true,
-    lengthChange: true,
     searching: true,
     ordering: true,
     stateSave: false,
     autoWidth: true,
-    lengthMenu: [
-      [10, 25, 50, 100, 250, 500, -1],
-      [10, 25, 50, 100, 250, 500, 'All']
-    ],
-    pageLength: 25,
+    // Infinite scroll (DataTables Scroller) instead of classic pagination.
+    // serverSide is set per-list; Scroller drives the start/length the server
+    // already implements in api/helpers/datatables/get-data.js.
+    scroller: true,
+    scrollY: '52vh',
+    scrollCollapse: true,
+    deferRender: true,
+    responsive: false,
     buttons: [
       {
         extend: 'selectAll',
@@ -74,7 +76,6 @@ $.fn.registerTable = function(onSelect, opts) {
     columnDefs: [
       { targets: '_all', defaultContent: '' }
     ],
-    pagingType: 'simple_numbers',
     select: {
       style: 'multi+shift'
     },
@@ -83,10 +84,30 @@ $.fn.registerTable = function(onSelect, opts) {
       caseInsen: true,
       smart: true
     },
-    dom: "<'row'<'col-sm-6'l><'col-sm-6'f>>B<'row'<'col-sm-12'tr>><'row'<'col-sm-5'i><'col-sm-7'p>>",
+    // Scroller replaces the length menu (l) and pagination (p); keep search (f),
+    // buttons (B), table+processing (tr) and info (i).
+    dom: "<'row'<'col-sm-12'f>>B<'row'<'col-sm-12'tr>><'row'<'col-sm-12'i>>",
     retrieve: true,
     processing: true
   });
+
+  // Opt-in "Create new" button (createMode: 'modal' | 'page'). Lists without a
+  // create route simply omit it. 'page' navigates to /{plural}/create; 'modal'
+  // lazy-loads that same server-rendered form into the shared #entityModal.
+  if (opts.createMode === 'modal' || opts.createMode === 'page') {
+    let createMode = opts.createMode, createLabel = opts.createLabel;
+    opts.buttons = [{
+      text: '<i class="fa fa-plus"></i> ' + (createLabel || 'Create New'),
+      className: 'btn-success',
+      action: function(e, dt) {
+        let url = window.location.pathname.replace(/\/$/, '') + '/create';
+        if (createMode === 'page') { window.location = url; return; }
+        window.fogCreateModal(url, dt);
+      }
+    }].concat(opts.buttons);
+  }
+  delete opts.createMode;
+  delete opts.createLabel;
 
   // Per-list extra toolbar buttons (e.g. host bulk actions) appended to the
   // shared Select/Edit/Delete set.
@@ -97,7 +118,7 @@ $.fn.registerTable = function(onSelect, opts) {
 
   let table = $(this).DataTable(opts);
 
-  if (onSelect !== undefined && typeof onSelect === 'functin') {
+  if (onSelect !== undefined && typeof onSelect === 'function') {
     table.on('select deselect', function(e, dt, type, indexes) {
       onSelect(dt.rows({selected: true}));
     });
@@ -109,3 +130,99 @@ $.readableBytes = function(bytes) {
   var i = Math.floor(Math.log(bytes) / Math.log(1024));
   return `${(bytes / Math.pow(1024, i)).toFixed(2) * 1} ${sizes[i]}`;
 };
+
+// Shared "create new <thing>" modal. Lazy-loads the exact same server-rendered
+// /{plural}/create form used for full-page create, AJAX-submits it (JSON), then
+// closes and reloads the table. Used by the registerTable "Create New" button
+// when createMode === 'modal'. Degrades to a full-page navigation if the modal
+// or Bootstrap isn't present.
+(function() {
+  function notify(type, text) {
+    try {
+      if (window.PNotify && typeof PNotify.alert === 'function') {
+        PNotify.alert({ type: type, text: text, delay: 2500 });
+      }
+    } catch (e) { /* toast is best-effort; the reloaded row is the real feedback */ }
+  }
+  function clearError(container) {
+    let e = container.querySelector('.fog-form-error');
+    if (e) { e.parentNode.removeChild(e); }
+  }
+  function showError(container, msg) {
+    clearError(container);
+    let d = document.createElement('div');
+    d.className = 'alert alert-danger m-3 fog-form-error';
+    d.textContent = msg;
+    container.insertBefore(d, container.firstChild);
+  }
+
+  window.fogCreateModal = function(url, dt) {
+    let modalEl = document.getElementById('entityModal');
+    if (!modalEl || !window.bootstrap) { window.location = url; return; }
+    let body = modalEl.querySelector('.modal-body'),
+      titleEl = modalEl.querySelector('.modal-title'),
+      modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+
+    body.innerHTML = '<div class="text-center p-4"><i class="fa fa-spinner fa-spin"></i> Loading…</div>';
+    modal.show();
+
+    // Bootstrap ignores a .hide() issued during the show transition, so a fast
+    // create round-trip can leave the modal open. Track the shown state and
+    // defer the close until the modal has actually finished opening.
+    let shown = false;
+    modalEl.addEventListener('shown.bs.modal', function() { shown = true; }, { once: true });
+    function safeHide() {
+      if (shown) { modal.hide(); }
+      else { modalEl.addEventListener('shown.bs.modal', function() { modal.hide(); }, { once: true }); }
+    }
+
+    fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' }, credentials: 'same-origin' })
+      .then(function(r) { return r.text(); })
+      .then(function(html) {
+        let doc = new DOMParser().parseFromString(html, 'text/html'),
+          // Scope to the page content so we never grab a navbar/search <form>.
+          form = doc.querySelector('.app-content form') || doc.querySelector('form'),
+          hdr = doc.querySelector('.app-content-header h3, .card-title');
+        if (titleEl) { titleEl.textContent = hdr ? hdr.textContent.trim() : 'Create'; }
+        if (!form) { showError(body, 'Could not load the form.'); return; }
+        body.innerHTML = '';
+        body.appendChild(form);
+
+        // The generated Cancel button is a submit; in the modal it just closes.
+        let cancel = form.querySelector('.btn-warning');
+        if (cancel) {
+          cancel.setAttribute('type', 'button');
+          cancel.addEventListener('click', function() { modal.hide(); });
+        }
+
+        form.addEventListener('submit', function(ev) {
+          ev.preventDefault();
+          clearError(body);
+          let payload = new URLSearchParams(new FormData(form)).toString();
+          fetch(form.getAttribute('action'), {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+              'Accept': 'application/json',
+              'X-Requested-With': 'XMLHttpRequest',
+              'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: payload
+          }).then(function(r) {
+            return r.json().catch(function() { return {}; }).then(function(j) {
+              return { ok: r.ok, body: j };
+            });
+          }).then(function(res) {
+            if (res.ok && res.body && res.body.ok) {
+              safeHide();
+              if (dt) { dt.ajax.reload(null, false); }
+              notify('success', 'Created successfully.');
+            } else {
+              showError(body, (res.body && res.body.message) || 'Could not save. Please check your input.');
+            }
+          }).catch(function() { showError(body, 'Network error — please try again.'); });
+        });
+      })
+      .catch(function() { showError(body, 'Could not load the form.'); });
+  };
+})();

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,8 +19,9 @@ JWT auth, and the seeded Administrator account are functional.
 
 **Implemented today:**
 
-- 8 models: `Host`, `Image`, `Group`, `Role`, `Setting`, `Task`, `User`,
-  `Workflow`.
+- 10 core models: `Host`, `Image`, `PxeMenu`, `Role`, `Setting`, `StorageGroup`,
+  `StorageNode`, `Task`, `User`, `Workflow`. (`Group` removed — ADR 0001; `Snapin`
+  (#55/#56) and `Printer` (#57) extracted to plugins.)
 - Generic CRUD driven by a `:model` route param (`api/controllers/general/*`),
   plus DataTables list/columns endpoints.
 - Auth: passport local + JWT (cookiecombo) with a granular per-model permissions
@@ -30,17 +31,19 @@ JWT auth, and the seeded Administrator account are functional.
 - Interactive installer (`tools/setup/index.js`) and a non-interactive dev setup
   (`tools/setup/dev.js`).
 
-**Gap vs. FOG 1.6 (large).** The sidebar (`config/globals.js`) advertises much
-more than exists. None of the following have models/controllers/views yet:
+**Gap vs. FOG 1.6 (still large).** Core entity *models* now largely exist (see
+Phase 1); the remaining gaps are behavior, breadth, and views — not schema:
 
-- Storage Groups, Storage Nodes (core to imaging & replication)
-- Modules/Snapins, Printers, iPXE menus
 - Multicast, Pending Hosts / Pending MACs (host approval)
 - Import/Export for every entity
 - A real imaging engine (capture/deploy controllers are stubs)
 - The 1.x background daemons (TaskScheduler, Image/Snapin replicators,
   MulticastManager, PingHosts, ImageSize, SnapinHash, FileDeleter)
 - The hundreds of `FOG_*` global settings 1.x seeds
+- Views: per-entity **list** views exist, but the per-entity **create forms**
+  aren't built (`views/pages/partials/create/` is empty) and the list pages have
+  no "Create new" entry point. (The `snapin` plugin is the exception — it ships
+  its own create page.)
 
 `tools/migrate/` is a Mongo *schema-revision* framework, **not** a 1.x-MySQL →
 2.0 data importer; that importer does not exist yet.
@@ -84,12 +87,16 @@ automatically gets full REST CRUD via the generic `:model` routes once it has a
 
 - [x] `StorageGroup` + `StorageNode` (with a bidirectional association) —
       mirrors 1.x `nfsGroups` / `nfsGroupMembers`.
-- [x] `Snapin` — mirrors 1.x `snapins`. (The sidebar labels these "Modules"; the
-      model is named `Snapin` to match 1.x domain language and avoid shadowing
-      Node's `Module` global. Sidebar label/route to be reconciled later.)
-- [x] `Printer` — mirrors 1.x `printers`. NOTE: the 1.x `pModel` field is exposed
-      as `printerModel`, not `model`, because the generic route param `:model`
-      would otherwise clobber a body field named `model`.
+- [x] `Snapin` — **extracted to the `snapin` plugin** (PRs #55/#56); no longer a
+      core model. It contributes its own `snapin` model + permissions + list/create
+      pages + the host "Snapins" tab (`extends.host`, links in the plugin's own
+      `plugin_snapin_host` collection). (Sidebar still labels snapins "Modules" in
+      places — reconcile later.)
+- [x] `Printer` — **extracted to the `printer` plugin** (PR #57); no longer a core
+      model. Contributes its own `printer` model + permissions + list/create pages
+      + the host "Printers" tab (`extends.host`; host links + per-host
+      `defaultPrinter`/level in `plugin_printer_host` / `plugin_printer_hostcfg`).
+      Mirrors 1.x `printers`.
 - [x] `PxeMenu` — mirrors 1.x `pxeMenuOptions` (the sidebar's "iPXE Menu"). The
       separate 1.x `ipxe` product/manufacturer/MAC → boot-file mapping table is
       deferred until the boot/imaging flow needs it.
@@ -98,14 +105,16 @@ automatically gets full REST CRUD via the generic `:model` routes once it has a
       compress/etc. on Image). Existing fog-node fields/associations preserved.
       Image lookup FKs (`imageType`/`imagePartitionType`/`os`) kept as numeric
       ids for now.
-- [x] Host↔Snapin, Host↔Printer, Group↔Snapin, Group↔Printer many-to-many
-      associations + Host `defaultPrinter` (1.x `printerAssoc.isDefault`).
-      Relationships are defined and populate via the API. **Follow-up:**
-      *assigning* members through the API needs controller support — the generic
+- [x] Host↔Printer / Host↔Snapin assignments + per-host `defaultPrinter` — **now
+      owned by the `printer`/`snapin` plugins** (links in each plugin's own
+      `plugin_*_host` collections via `extends.host`), not core associations.
+      `Group↔*` associations were removed with the Group entity (ADR 0001: groups
+      → host `tags` + bulk list actions). Remaining core association:
+      StorageGroup↔StorageNode (bidirectional). **Follow-up:** *assigning* core
+      collection members through the API needs controller support — the generic
       `update` doesn't set collections and the blueprint nested
       `/:model/:id/:assoc/:fk` routes are shadowed by the custom `:model` routes
-      (return 404). Add explicit add/remove-to-collection endpoints (mirroring
-      the existing `group/register`, `role/assign` pattern).
+      (return 404). Add explicit add/remove endpoints (mirroring `role/assign`).
 - [ ] `Task` field parity (gated partly by the client/FOS decision).
 - [ ] Lookup models to replace numeric FKs: ImageType, PartitionType, OS.
 - [ ] Seed the `FOG_*` settings 1.x expects.

--- a/plugins/printer/list.partial.js
+++ b/plugins/printer/list.partial.js
@@ -1,6 +1,7 @@
 (function($) {
   let path = $(location).attr('pathname').replace(/s$/,'');
   $('#listtable').registerTable(undefined, {
+    createMode: 'modal',
     order: [
       [0, 'asc']
     ],

--- a/plugins/snapin/list.partial.js
+++ b/plugins/snapin/list.partial.js
@@ -1,6 +1,7 @@
 (function($) {
   let path = $(location).attr('pathname').replace(/s$/,'');
   $('#listtable').registerTable(undefined, {
+    createMode: 'modal',
     order: [
       [0, 'asc']
     ],

--- a/views/layouts/layout.ejs
+++ b/views/layouts/layout.ejs
@@ -113,6 +113,21 @@
     <!--TEMPLATES-->
     <!--TEMPLATES END-->
 
+    <% if (req.user) { %>
+    <!-- Shared "create new <thing>" modal, populated by fogCreateModal() in fog.common.js -->
+    <div class="modal fade" id="entityModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Create</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body"></div>
+        </div>
+      </div>
+    </div>
+    <% } %>
+
 
     <!--
         Server-side View Locals
@@ -161,11 +176,12 @@
     <script src="/js/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/pace-js/pace.min.js"></script>
     <script src="/dependencies/cloud.js"></script>
-    <script src="/dependencies/parasails.js"></script>
+    <script src="/js/datatables.net/js/dataTables.min.js"></script>
     <script src="/js/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
     <script src="/js/datatables.net-autofill/js/dataTables.autoFill.min.js"></script>
     <script src="/js/datatables.net-buttons/js/dataTables.buttons.min.js"></script>
     <script src="/js/datatables.net-buttons/js/buttons.colVis.min.js"></script>
+    <script src="/js/datatables.net-buttons/js/buttons.html5.min.js"></script>
     <script src="/js/datatables.net-buttons/js/buttons.print.min.js"></script>
     <script src="/js/datatables.net-colreorder/js/dataTables.colReorder.min.js"></script>
     <script src="/js/datatables.net-keytable/js/dataTables.keyTable.min.js"></script>
@@ -178,7 +194,7 @@
     <script src="/admin-lte/dist/js/adminlte.min.js"></script>
     <script src="/js/@pnotify/core/dist/PNotify.js"></script>
     <script src="/js/@pnotify/mobile/dist/PNotifyMobile.js"></script>
-    <script src="/js/chartjs-plugin-labels.js"></script>
+    <script src="/js/chart.umd.min.js"></script>
     <script src="/js/datatables.net-autofill-bs4/js/autoFill.bootstrap4.min.js"></script>
     <script src="/js/datatables.net-buttons-bs4/js/buttons.bootstrap4.min.js"></script>
     <script src="/js/datatables.net-colreorder-bs4/js/colReorder.bootstrap4.min.js"></script>
@@ -191,10 +207,10 @@
     <script src="/js/datatables.net-select-bs4/js/select.bootstrap4.min.js"></script>
     <script src="/js/inputmask/dist/jquery.inputmask.min.js"></script>
     <script src="/js/jszip/dist/jszip.min.js"></script>
-    <script src="/js/pages/create.page.js"></script>
-    <script src="/js/pages/list.page.js"></script>
     <script src="/js/pdfmake/build/pdfmake.min.js"></script>
     <script src="/fog/fog.common.js"></script>
+    <script src="/fog/fog.maclist.js"></script>
+    <script src="/fog/fog.search.js"></script>
     <!--SCRIPTS END-->
     <% if (partialname) { %>
     <script type="text/javascript">

--- a/views/pages/list.ejs
+++ b/views/pages/list.ejs
@@ -18,7 +18,7 @@
           </div>
           <div class="card-body">
             <div class="container">
-              <table id="listtable" class="display table table-bordered table-striped listtable no-footer dtr-inline collapsed" role="grid">
+              <table id="listtable" class="display table table-bordered table-striped listtable no-footer" role="grid">
                 <thead>
                   <tr class="header" role="row">
                     <% for (var i = 0;i < theads.length;i++) { %>

--- a/views/pages/partials/list/host.js
+++ b/views/pages/partials/list/host.js
@@ -13,6 +13,7 @@
     });
   }
   $('#listtable').registerTable(undefined, {
+    createMode: 'page',
     order: [
       [0, 'asc']
     ],

--- a/views/pages/partials/list/image.js
+++ b/views/pages/partials/list/image.js
@@ -1,6 +1,7 @@
 (function($) {
   let path = $(location).attr('pathname').replace(/s$/,'');
   $('#listtable').registerTable(undefined, {
+    createMode: 'modal',
     order: [
       [0, 'asc']
     ],

--- a/views/pages/partials/list/pxemenu.js
+++ b/views/pages/partials/list/pxemenu.js
@@ -1,6 +1,7 @@
 (function($) {
   let path = $(location).attr('pathname').replace(/s$/,'');
   $('#listtable').registerTable(undefined, {
+    createMode: 'modal',
     order: [
       [0, 'asc']
     ],

--- a/views/pages/partials/list/storagegroup.js
+++ b/views/pages/partials/list/storagegroup.js
@@ -1,6 +1,7 @@
 (function($) {
   let path = $(location).attr('pathname').replace(/s$/,'');
   $('#listtable').registerTable(undefined, {
+    createMode: 'modal',
     order: [
       [0, 'asc']
     ],

--- a/views/pages/partials/list/storagenode.js
+++ b/views/pages/partials/list/storagenode.js
@@ -1,6 +1,7 @@
 (function($) {
   let path = $(location).attr('pathname').replace(/s$/,'');
   $('#listtable').registerTable(undefined, {
+    createMode: 'modal',
     order: [
       [0, 'asc']
     ],

--- a/views/pages/partials/list/user.js
+++ b/views/pages/partials/list/user.js
@@ -1,6 +1,7 @@
 (function($) {
   let path = $(location).attr('pathname').replace(/s$/,'');
   $('#listtable').registerTable(undefined, {
+    createMode: 'modal',
     order: [
       [0, 'asc']
     ],


### PR DESCRIPTION
## What

- **Create New** button on list views (opt-in `createMode` on the shared `registerTable` wrapper). Simple entities open a **modal** that lazy-loads the existing server-rendered `/{plural}/create` form, AJAX-submits it, then closes + reloads the table. **Host** uses `createMode:'page'` (its multi-tab, plugin-extended form stays full-page).
- `general/save` answers **XHR submits with JSON** (`{ok,id}` / `{ok:false,message}`); full-page submits still redirect.
- Lists switch to **DataTables Scroller (infinite scroll)**; dropped the responsive-collapse classes that conflict with it; fixed the `onSelect 'functin'` typo.
- Per-list `createMode`: host=page; image/pxemenu/storagegroup/storagenode/user + snapin/printer plugins=modal.
- Bundles the in-progress `layout.ejs` script wiring (DataTables core, buttons.html5, fog.search) the list UI depends on. `docs/roadmap.md` synced to current state (separate commit).

## Verification

Driven end-to-end via **headless Chrome (DevTools Protocol)**: list renders with scroller + search + Create button (no JS errors); Create opens the modal, fill+submit **creates the record and closes the modal**, table reloads; Host shows the page-mode button. Server: `POST /{plural}/create` as XHR → `200 {ok:true,id}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)