### PR TITLE
feat(host): bulk actions can target all hosts matching the current filter

### DIFF
--- a/api/controllers/host/bulk.js
+++ b/api/controllers/host/bulk.js
@@ -17,9 +17,6 @@ module.exports = {
 
     if (!perms || !perms.update) { return res.forbidden(); }
 
-    let ids = Array.isArray(p.id) ? p.id : (p.id ? [p.id] : []);
-    if (!ids.length) { return res.badRequest({ error: 'No hosts selected.' }); }
-
     let toArr = (v) => (Array.isArray(v) ? v : (v ? [v] : [])).map((x) => String(x).trim()).filter(Boolean),
       addTags = toArr(p.addTags),
       removeTags = toArr(p.removeTags).map((t) => t.toLowerCase());
@@ -37,8 +34,23 @@ module.exports = {
       }
     }
 
-    let hosts = await sails.models.host.find({ id: ids }),
-      updated = 0;
+    // Target set: an explicit selection (id list), or -- when `all` is set --
+    // every host matching the current list search (name/description/tags
+    // substring; empty search = every host). Filtering in JS keeps the match
+    // semantics predictable and avoids adapter-specific array/contains quirks.
+    let hosts, updated = 0;
+    if (p.all) {
+      let s = String(p.search || '').trim().toLowerCase(),
+        everyHost = await sails.models.host.find();
+      hosts = s
+        ? everyHost.filter((h) => [h.name, h.description, Array.isArray(h.tags) ? h.tags.join(' ') : '']
+          .join(' ').toLowerCase().indexOf(s) !== -1)
+        : everyHost;
+    } else {
+      let ids = Array.isArray(p.id) ? p.id : (p.id ? [p.id] : []);
+      if (!ids.length) { return res.badRequest({ error: 'No hosts selected.' }); }
+      hosts = await sails.models.host.find({ id: ids });
+    }
     for (let h of hosts) {
       let set = {};
       if (addTags.length || removeTags.length) {

--- a/views/pages/partials/list/host.js
+++ b/views/pages/partials/list/host.js
@@ -12,6 +12,22 @@
       complete: function() { dt.ajax.reload(); }
     });
   }
+  // Apply a bulk change to the selected rows, or -- when nothing is selected --
+  // to every host matching the current search (confirmed by count). With
+  // infinite scroll, selection only covers loaded rows, so "all matching" is how
+  // you act on the whole filtered set. `desc` is shown in the confirm prompt.
+  function applyBulk(dt, body, desc) {
+    let ids = selectedIds(dt);
+    if (ids.length) {
+      bulk(dt, $.extend({id: ids}, body));
+      return;
+    }
+    let n = dt.page.info().recordsDisplay,
+      search = dt.search() || '',
+      scope = search ? `all ${n} host(s) matching "${search}"` : `ALL ${n} host(s)`;
+    if (!window.confirm(`No rows selected — ${desc} for ${scope}?`)) { return; }
+    bulk(dt, $.extend({all: true, search: search}, body));
+  }
   $('#listtable').registerTable(undefined, {
     createMode: 'page',
     order: [
@@ -22,31 +38,25 @@
       {
         text: '<i class="fa fa-tag"></i> Add Tag',
         action: function(e, dt) {
-          let ids = selectedIds(dt);
-          if (!ids.length) { window.alert('Select one or more hosts.'); return; }
-          let tag = window.prompt(`Tag to ADD to ${ids.length} host(s):`);
+          let tag = window.prompt('Tag to ADD:');
           if (!tag) { return; }
-          bulk(dt, {id: ids, addTags: [tag]});
+          applyBulk(dt, {addTags: [tag]}, `add tag "${tag}"`);
         }
       },
       {
         text: '<i class="fa fa-tag"></i> Remove Tag',
         action: function(e, dt) {
-          let ids = selectedIds(dt);
-          if (!ids.length) { window.alert('Select one or more hosts.'); return; }
-          let tag = window.prompt(`Tag to REMOVE from ${ids.length} host(s):`);
+          let tag = window.prompt('Tag to REMOVE:');
           if (!tag) { return; }
-          bulk(dt, {id: ids, removeTags: [tag]});
+          applyBulk(dt, {removeTags: [tag]}, `remove tag "${tag}"`);
         }
       },
       {
         text: '<i class="fa fa-desktop"></i> Set Image',
         action: function(e, dt) {
-          let ids = selectedIds(dt);
-          if (!ids.length) { window.alert('Select one or more hosts.'); return; }
-          let name = window.prompt(`Image NAME to assign to ${ids.length} host(s) (blank to clear):`);
+          let name = window.prompt('Image NAME to assign (blank to clear):');
           if (name === null) { return; }
-          bulk(dt, {id: ids, image: name});
+          applyBulk(dt, {image: name}, name ? `set image "${name}"` : 'clear image');
         }
       }
     ],


### PR DESCRIPTION
With infinite scroll, row selection only covers **loaded** rows, so "tag/image all N hosts matching X" wasn't possible. This closes that gap (the follow-up we parked during the create-modal grill).

- **Server** (`host/bulk.js`): accepts `{ all:true, search }` as well as `{ id:[...] }`. In `all` mode it applies the change to every host whose `name`/`description`/`tags` contain the search term (empty search = every host). JS-side filtering keeps match semantics predictable.
- **Client** (`host.js`): bulk buttons act on the **selection** when rows are selected, or — when nothing is selected — on the **whole filtered set after a confirm showing the count** (e.g. *"add tag \"x\" for all 4000 host(s) matching \"lab-a\"?"*). Never a silent mass-update.

Verified end-to-end via headless Chrome: created a throwaway host, searched, clicked **Add Tag** with no selection, auto-accepted the prompt + confirm — **only the matching host was tagged**, other hosts untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)