### PR TITLE
fix(build): stop grunt re-injecting the dropped polyfill on every lift

### DIFF
--- a/tasks/register/build.js
+++ b/tasks/register/build.js
@@ -12,7 +12,7 @@
  */
 module.exports = function(grunt) {
   grunt.registerTask('build', [
-    'polyfill:dev', //« uncomment to ALSO transpile during development (for broader browser compat.)
+    // 'polyfill:dev', // disabled — babel-polyfill not needed for modern target browsers (see PR #61)
     'compileAssets',
     'babel',        //« uncomment to ALSO transpile during development (for broader browser compat.)
     'linkAssetsBuild',

--- a/tasks/register/default.js
+++ b/tasks/register/default.js
@@ -16,7 +16,7 @@ module.exports = function (grunt) {
 
 
   grunt.registerTask('default', [
-    'polyfill:dev', //« uncomment to ALSO transpile during development (for broader browser compat.)
+    // 'polyfill:dev', // disabled — babel-polyfill not needed for modern target browsers (re-injected the dropped <script> on every lift; see PR #61)
     'compileAssets',
     'babel',        //« uncomment to ALSO transpile during development (for broader browser compat.)
     'linkAssets',


### PR DESCRIPTION
PR #61 removed the `polyfill.min.js` `<script>` from `layout.ejs`, but that `<!--SCRIPTS-->` block is **regenerated by grunt's linker on every `sails lift`**, and the active `polyfill:dev` task re-prepended babel-polyfill each time — so the removal never stuck and `layout.ejs` kept showing dirty after every dev restart (which is why it trailed onto new branches all session).

Comment out `polyfill:dev` in the dev `default`/`build` tasklists so the linker stops adding it. Modern target browsers (AdminLTE4 / BS5 / jQuery 3.7) don't need it. `polyfill:prod` (production transpilation) is left untouched.

**Verified:** after a full `sails lift`, `layout.ejs` no longer regains the polyfill tag and the working tree stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)