### PR TITLE
docs(readme): document persistent deployment (systemd + nginx proxy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,151 @@ node tools/setup/index.js   # prompts for DB, admin account, webserver, etc.
 npm start                   # NODE_ENV=production node app.js
 ```
 
+## Persistent deployment (systemd autostart + nginx reverse proxy)
+
+To run fog-node as a managed service that survives reboots — and reach it on the
+standard ports (80/443) behind nginx instead of `:1337` — wire it up with systemd
+and a reverse proxy. The example below targets a Linux host with **rootless
+Podman**; adjust the IP, user, and paths to your machine.
+
+### 1. MongoDB as a Podman Quadlet (systemd `--user`)
+
+`~/.config/containers/systemd/fog-node-mongo.container`:
+
+```ini
+[Unit]
+Description=fog-node MongoDB (podman)
+After=network-online.target
+Wants=network-online.target
+
+[Container]
+ContainerName=fog-node-mongo
+Image=docker.io/library/mongo:7
+PublishPort=127.0.0.1:27017:27017
+Volume=fog-node-mongo-data:/data/db
+
+[Service]
+Restart=always
+TimeoutStartSec=300
+
+[Install]
+WantedBy=default.target
+```
+
+`systemctl --user daemon-reload` generates `fog-node-mongo.service` from this
+file. The named volume `fog-node-mongo-data` keeps your data across container
+re-creation.
+
+### 2. fog-node as a systemd `--user` service
+
+`~/.config/systemd/user/fog-node.service` (replace `<user>`):
+
+```ini
+[Unit]
+Description=fog-node (Sails.js) server on :1337
+After=fog-node-mongo.service network-online.target
+Wants=fog-node-mongo.service network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+WorkingDirectory=/home/<user>/fog-node
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+ExecStart=/usr/local/bin/node app.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+`Restart=on-failure` also covers the boot race where fog-node lifts before
+MongoDB is accepting connections — it just retries.
+
+### 3. Enable autostart at boot
+
+```sh
+# let your user's services start at boot without an active login session
+sudo loginctl enable-linger "$USER"
+
+systemctl --user daemon-reload
+systemctl --user enable --now fog-node-mongo.service
+systemctl --user enable --now fog-node.service
+```
+
+Manage with `systemctl --user {status,restart,stop} fog-node`; follow logs via
+`journalctl --user -u fog-node -f`.
+
+### 4. nginx reverse proxy (80 + 443 → :1337)
+
+Sails uses socket.io, so the proxy **must** forward WebSocket upgrades or the live
+UI/sockets break. `/etc/nginx/conf.d/fog-node.conf` (replace `10.0.0.10` with your
+host's IP):
+
+```nginx
+map $http_upgrade $fognode_connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 80;
+    server_name 10.0.0.10;
+    client_max_body_size 3000m;
+    location / {
+        proxy_pass http://127.0.0.1:1337;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $fognode_connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400;
+    }
+}
+
+server {
+    listen 10.0.0.10:443 ssl;
+    server_name 10.0.0.10;
+    client_max_body_size 3000m;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_certificate     /etc/nginx/certs/fog-node.crt;
+    ssl_certificate_key /etc/nginx/certs/fog-node.key;
+    location / {
+        proxy_pass http://127.0.0.1:1337;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $fognode_connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400;
+    }
+}
+```
+
+Self-signed cert for a LAN install, then test + reload:
+
+```sh
+sudo mkdir -p /etc/nginx/certs
+sudo openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+  -keyout /etc/nginx/certs/fog-node.key -out /etc/nginx/certs/fog-node.crt \
+  -subj "/CN=10.0.0.10" -addext "subjectAltName=IP:10.0.0.10"
+
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+> **Gotchas**
+> - If you host other nginx vhosts, give each its own `ssl_session_cache` zone
+>   name (or omit it). Duplicate `shared:NAME:size` zones with mismatched sizes
+>   make `nginx -t` fail.
+> - The app's entry point is `/login`; a bare `/` returns 403 by design.
+
 TODO:
  Build views for all the different components
- Build systemctl script (linux)
+ Build systemctl script (linux) — documented above ("Persistent deployment")
  Build launchctl script (macos)
  Build Service/Task Scheduler to start script (windows)
  Test


### PR DESCRIPTION
## What

Adds a **Persistent deployment** section to the README covering how to run fog-node as a reboot-safe service behind a real reverse proxy, instead of a hand-started `node app.js` on `:1337`.

Documents the exact setup we just stood up on a dev box running two FOG environments side by side:

1. **MongoDB** as a Podman **Quadlet** (`systemd --user`), data in a named volume.
2. **fog-node** as a `systemd --user` service (`After=` mongo, `Restart=on-failure` to ride out the boot race).
3. **linger** so user services start at boot without a login session.
4. **nginx reverse proxy** (80 + 443 → `:1337`) — including the `map`/`Upgrade`/`Connection` headers **socket.io requires** (Sails breaks without them), plus a self-signed-cert recipe.

Generalized (placeholder IP/user/paths) so it's reusable, not tied to one host. Fills the existing `Build systemctl script (linux)` TODO.

## Notes

- Docs only — no code changes.
- Includes the two gotchas we actually hit: duplicate `ssl_session_cache` zone names failing `nginx -t`, and `/` returning 403 by design (entry point is `/login`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)