### PR TITLE
feat(storage): HTTP-internal storage model + unified image path + dashboard empty-state

### DIFF
--- a/api/controllers/pages/dashboard.js
+++ b/api/controllers/pages/dashboard.js
@@ -2,7 +2,6 @@ const fs = require('fs-extra'),
   path = require('path'),
   appRoot = path.join(__dirname, '..', '..', '..'),
   partialPath = path.join(appRoot, 'views', 'pages', 'partials'),
-  imagePath = `${path.parse(appRoot).root}images`,
   si = require('systeminformation'),
   moment = require('moment'),
   checkDiskSpace = require('check-disk-space').default;
@@ -41,7 +40,8 @@ module.exports = {
 
     // Disk usage of the image store. Fall back to the filesystem root when the
     // image path does not exist (e.g. in development).
-    let free = 0, size = 0, used = 0;
+    let imagePath = sails.config.custom.imageStorePath || '/images',
+      free = 0, size = 0, used = 0;
     try {
       let diskSpace = await checkDiskSpace(imagePath);
       size = diskSpace.size; free = diskSpace.free; used = size - free;

--- a/api/helpers/image/stream.js
+++ b/api/helpers/image/stream.js
@@ -1,7 +1,6 @@
 const path = require('path'),
   fs = require('fs'),
-  progress = require('progress-stream'),
-  imageDir = path.join(__dirname, '..', '..', '..', 'images');
+  progress = require('progress-stream');
 module.exports = {
   friendlyName: 'Stream',
   description: 'Stream image.',
@@ -39,7 +38,8 @@ module.exports = {
   fn: async function (inputs, exits) {
     let id = inputs.id,
       partition = inputs.partition,
-      target = inputs.target;
+      target = inputs.target,
+      imageDir = sails.config.custom.imageStorePath || '/images';
     await sails.helpers.image.aquireReadLock(id).switch({
       error: async (err) => {
         return exits.error(err);

--- a/api/helpers/system/hwinfo.js
+++ b/api/helpers/system/hwinfo.js
@@ -2,7 +2,6 @@ const si = require('systeminformation'),
   fs = require('fs-extra'),
   path = require('path'),
   appRoot = path.join(__dirname, '..', '..', '..'),
-  imagePath = `${path.parse(appRoot).root}images`,
   moment = require('moment'),
   checkDiskSpace = require('check-disk-space').default;
 module.exports = {
@@ -50,6 +49,7 @@ module.exports = {
     });
 
     // Filesystem info
+    let imagePath = sails.config.custom.imageStorePath || '/images';
     size = await checkDiskSpace(imagePath).then(async diskspace => {
       let free = diskspace.free,
         total = diskspace.size,

--- a/api/models/StorageNode.js
+++ b/api/models/StorageNode.js
@@ -34,8 +34,7 @@ module.exports = {
       required: true
     },
     ftppath: {
-      type: 'string',
-      required: true
+      type: 'string'
     },
     snapinpath: {
       type: 'string'
@@ -47,12 +46,10 @@ module.exports = {
       type: 'string'
     },
     user: {
-      type: 'string',
-      required: true
+      type: 'string'
     },
     pass: {
-      type: 'string',
-      required: true
+      type: 'string'
     },
     key: {
       type: 'string'

--- a/config/custom.js
+++ b/config/custom.js
@@ -10,6 +10,11 @@
 
 module.exports.custom = {
 
+  // Image store: one folder per image -> <imageStorePath>/<image>/<partition>.img.
+  // Single source of truth for the deploy streamer, dashboard/hwinfo disk usage,
+  // and the image-store scan. Matches FOG's storageLocation (default /images).
+  imageStorePath: '/images',
+
   /***************************************************************************
   *                                                                          *
   * Any other custom config this Sails app should use during development.    *

--- a/views/pages/partials/dashboard.js
+++ b/views/pages/partials/dashboard.js
@@ -11,21 +11,23 @@
   let qavail = Number($('#avail').val()) || 0,
     qactive = Number($('#active').val()) || 0,
     qstaged = Number($('#staged').val()) || 0,
+    qtotal = qavail + qactive + qstaged,
     activeUsageCanvas = $('#activityUsage').get(0);
   if (activeUsageCanvas) {
+    // Empty state: a 0/0/0 doughnut renders blank, so when there's no capacity
+    // and no tasks show a single neutral "No activity" ring instead of nothing.
+    let activityData = qtotal > 0
+      ? {
+        labels: [`Available: ${qavail}`, `Active: ${qactive}`, `Staged: ${qstaged}`],
+        datasets: [{ data: [qavail, qactive, qstaged], backgroundColor: ['#28a745', '#dc3545', '#007bff'] }]
+      }
+      : {
+        labels: ['No activity'],
+        datasets: [{ data: [1], backgroundColor: ['#adb5bd'] }]
+      };
     new Chart(activeUsageCanvas.getContext('2d'), {
       type: 'doughnut',
-      data: {
-        labels: [
-          `Available: ${qavail}`,
-          `Active: ${qactive}`,
-          `Staged: ${qstaged}`
-        ],
-        datasets: [{
-          data: [qavail, qactive, qstaged],
-          backgroundColor: ['#28a745', '#dc3545', '#007bff']
-        }]
-      },
+      data: activityData,
       options: {
         responsive: true,
         maintainAspectRatio: false,


### PR DESCRIPTION
Groundwork from the dashboard/storage discussion (foundation for the image-store scan PR to follow).

- **Storage nodes are HTTP-internal.** fog-node streams/receives images over local HTTP and never touches a node's SSH/FTP creds (1.x `nfsGroupMembers` carryover). So `user`/`pass`/`ftppath` are now **optional** — a node only needs `name`/`ip`/`path`/`maxClients`.
- **One image-store path.** New `config.custom.imageStorePath` (default `/images`, matching FOG's `storageLocation`); the deploy streamer, dashboard, and hwinfo all use it. Fixes the streamer reading `<appRoot>/images` while disk-usage read `/images`.
- **Dashboard Activity empty-state.** A 0/0/0 doughnut rendered blank; now shows a neutral "No activity" ring until there's capacity/tasks.

Verified via headless browser: a node creates with **no creds** (200); the doughnut shows the empty ring at 0 capacity and `Available=maxClients` (10) once a master node exists. (A `DefaultMember` node was seeded so the ring shows on this box.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)