### PR TITLE
feat(image): on-demand 'Scan image store' to auto-create Image records from disk

### DIFF
--- a/api/controllers/image/scan.js
+++ b/api/controllers/image/scan.js
@@ -1,0 +1,14 @@
+module.exports = {
+  friendlyName: 'Scan image store',
+  description: 'Scan the image store directory and create Image records for newly-found image folders.',
+  fn: async function () {
+    let req = this.req,
+      res = this.res,
+      perms = req.user && req.user.permissions && req.user.permissions.stock && req.user.permissions.stock.image;
+
+    // Creating image records, so require the image create permission.
+    if (!perms || !perms.create) { return res.forbidden(); }
+
+    return res.json(await sails.helpers.image.scanStore());
+  }
+};

--- a/api/helpers/image/scan-store.js
+++ b/api/helpers/image/scan-store.js
@@ -1,0 +1,48 @@
+const fs = require('fs'),
+  path = require('path');
+
+module.exports = {
+  friendlyName: 'Scan image store',
+  description: 'Discover image folders already on disk and create Image records ' +
+    'for any not yet defined. Create-only: never overwrites or deletes existing ' +
+    'images. A folder counts as an image when it holds at least one partition ' +
+    'file (e.g. d1p1.img).',
+  inputs: {},
+  exits: {
+    success: { outputFriendlyName: 'Scan result' }
+  },
+  fn: async function () {
+    let dir = sails.config.custom.imageStorePath || '/images',
+      // FOG system dirs that live under the store but are not images.
+      skip = ['dev', 'lost+found', 'postdownloadscripts', 'postinitscripts'],
+      result = { path: dir, found: [], created: [], skipped: [] };
+
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      return Object.assign(result, { error: `Cannot read image store '${dir}': ${err.message}` });
+    }
+
+    let known = new Set((await sails.models.image.find()).map((i) => i.name));
+
+    for (let entry of entries) {
+      if (!entry.isDirectory()) { continue; }
+      let name = entry.name;
+      if (name.startsWith('.') || skip.indexOf(name) !== -1) { continue; }
+
+      let hasPartition = false;
+      try {
+        hasPartition = fs.readdirSync(path.join(dir, name)).some((f) => /\.img$/i.test(f));
+      } catch (unused) { continue; }
+      if (!hasPartition) { continue; }
+
+      result.found.push(name);
+      if (known.has(name)) { result.skipped.push(name); continue; }
+
+      let img = await sails.models.image.create({ name, path: name, createdBy: 'scan' }).fetch();
+      result.created.push({ name, id: img.id });
+    }
+    return result;
+  }
+};

--- a/config/routes.js
+++ b/config/routes.js
@@ -55,6 +55,7 @@ module.exports.routes = {
   'GET /api/v1/search':                      {action: 'search'},
 
   // General API elements.
+  'POST /api/v1/image/scan':                 {action: 'image/scan'},
   'POST /api/v1/:model':                     {action: 'general/create'},
   'DELETE /api/v1/:model/:id?':              {action: 'general/destroy'},
   'GET /api/v1/:model/:id':                  {action: 'general/find'},

--- a/views/pages/partials/list/image.js
+++ b/views/pages/partials/list/image.js
@@ -5,6 +5,26 @@
     order: [
       [0, 'asc']
     ],
+    // Discover images already on disk (a folder with partition .img files) and
+    // create records for any not yet defined -- so synced/copied images appear
+    // without building each definition by hand.
+    extraButtons: [
+      {
+        text: '<i class="fa fa-folder-open"></i> Scan store',
+        action: function(e, dt) {
+          $.ajax({
+            url: '/api/v1/image/scan',
+            type: 'POST',
+            complete: function(xhr) {
+              let r = (xhr && xhr.responseJSON) || {},
+                n = (r.created || []).length;
+              window.alert(r.error ? r.error : (n ? `Discovered ${n} new image(s).` : 'No new images found.'));
+              dt.ajax.reload();
+            }
+          });
+        }
+      }
+    ],
     columns: [
       {data: 'name'},
       {data: 'protected'},


### PR DESCRIPTION
Register images already on disk without hand-building each definition — e.g. after syncing from another node or copying a folder in (the idea from the dashboard/storage discussion).

- New helper **`image/scanStore`**: lists `config.custom.imageStorePath` (`/images`); any subfolder holding a partition file (`*.img`) is an image; **create-only** inserts an `Image` (`name`=folder, `path`=folder, `createdBy='scan'`). Skips FOG system dirs (`dev`, `lost+found`, `postdownloadscripts`); never overwrites or deletes.
- **`POST /api/v1/image/scan`** (requires `image.create`) + a **"Scan store"** button on the Images list (alerts the count, reloads).

Verified against real `/images`: discovered `test` (has `d1p1/d1p2.img`) and created its record, **idempotent** on re-run (skips it), and left the pre-existing image untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)