### PR TITLE
chore(agents): scaffold mattpocock skills config (AGENTS.md + docs/agents)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+Agent / skill configuration for the **fog-node** repo.
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked as **GitHub issues** on `fogproject/fog-node` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default triage vocabulary — `needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix` (`wontfix` already exists; the rest are created on first triage). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context. ADRs in `docs/adr/`; no `CONTEXT.md` yet, so domain knowledge currently lives in `docs/roadmap.md` / `docs/ecosystem.md`. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,40 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase. **fog-node is single-context** (one domain, no `CONTEXT-MAP.md`).
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, if it exists.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in (e.g. `0001-imaging-core-and-plugin-model.md`).
+
+There is no `CONTEXT.md` yet. Until one exists, the de-facto domain docs are:
+
+- **`docs/roadmap.md`** — current state + phased plan toward FOG 1.6 parity.
+- **`docs/ecosystem.md`** — the FOGProject repo/plugin map.
+- **`docs/plugins.md`** — the plugin contract; **`docs/imaging.md`** — imaging/FOS notes.
+
+If `CONTEXT.md` doesn't exist, **proceed silently** — don't flag its absence or suggest creating it upfront. `/grill-with-docs` creates it lazily when domain terms or decisions actually get resolved.
+
+## File structure (single-context)
+
+```
+/
+├── CONTEXT.md            ← not present yet; created lazily by /grill-with-docs
+├── docs/
+│   ├── adr/0001-imaging-core-and-plugin-model.md
+│   ├── roadmap.md
+│   └── ecosystem.md
+└── api/ assets/ config/ views/ …
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md` (or, until it exists, the language used in `docs/roadmap.md` / `docs/adr/` — e.g. "Workflow", "Module/Snapin", "host fingerprint identity"). Don't drift to synonyms the docs explicitly avoid.
+
+If the concept you need isn't documented yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0001 (imaging core + plugin model) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,20 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on `fogproject/fog-node`. Use the `gh` CLI for all operations (`gh` infers the repo from `git remote -v` when run inside the clone).
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+> Repo state at setup: `wontfix` already exists on `fogproject/fog-node`; the other four labels do not yet exist and will be created the first time `triage` applies them. Edit the right-hand column if you later adopt different label names.


### PR DESCRIPTION
Scaffolds the per-repo config the engineering skills (`triage`, `to-issues`, `to-prd`, `improve-codebase-architecture`, …) read:

- `AGENTS.md` — root `## Agent skills` block.
- `docs/agents/issue-tracker.md` — GitHub (`gh` CLI) on `fogproject/fog-node`.
- `docs/agents/triage-labels.md` — default 5-role vocabulary (`wontfix` exists; the rest created on first triage).
- `docs/agents/domain.md` — single-context; ADRs in `docs/adr/`, domain knowledge currently in `docs/roadmap.md`/`ecosystem.md` (no `CONTEXT.md` yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)