### PR TITLE
feat: bandwidth time-range selector + search hosts by MAC/serial/asset/guid/tags

### DIFF
--- a/api/helpers/global-search.js
+++ b/api/helpers/global-search.js
@@ -32,11 +32,22 @@ module.exports = {
 
     // Escape the query so it is matched as a literal substring (no regex
     // injection / ReDoS from user input), then match case-insensitively.
-    let escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    let escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+      escaped = escapeRe(q);
 
-    // The user-facing entities and which string fields to search.
+    // MACs are stored as bare lower-case hex with no separators (e.g.
+    // "aabbccddeeff"), so strip any colon/hyphen/dot/space the user typed first
+    // -- lets "aa:bb:cc", "AA-BB-CC" and "aabbcc" all match the `macs` array.
+    let macStripped = q.replace(/[\s.:-]/g, ''),
+      macEscaped = macStripped ? escapeRe(macStripped) : '';
+
+    // The user-facing entities and which string fields to search. Hosts also
+    // match on their hardware identifiers (macs/serial/asset/guid) and their
+    // `tags` array, so a tech can paste a MAC/serial or type a (partial) tag and
+    // land on the host. `tags` is a string array; a case-insensitive substring
+    // regex matches any element, giving partial-tag matches for free.
     let searchConfig = [
-      { model: 'host', label: 'Hosts', fields: ['name', 'description', 'ip'] },
+      { model: 'host', label: 'Hosts', fields: ['name', 'description', 'ip', 'macs', 'serial', 'asset', 'guid', 'tags'] },
       { model: 'image', label: 'Images', fields: ['name', 'description'] },
       { model: 'storagegroup', label: 'Storage Groups', fields: ['name', 'description'] },
       { model: 'storagenode', label: 'Storage Nodes', fields: ['name', 'description', 'ip'] },
@@ -63,10 +74,18 @@ module.exports = {
         // (Waterline's `contains` is case-sensitive under sails-mongo).
         let db = sails.getDatastore(Model.datastore).manager,
           collection = db.collection(Model.tableName),
-          docs = await collection
-            .find({ $or: fields.map((f) => ({ [f]: { $regex: escaped, $options: 'i' } })) })
-            .limit(inputs.limit)
-            .toArray();
+          or = [];
+        for (let f of fields) {
+          if (f === 'macs') {
+            // Only search the bare-hex array when the stripped query still has
+            // something to match (skip e.g. a lone ":" that strips to empty).
+            if (macEscaped) { or.push({ macs: { $regex: macEscaped, $options: 'i' } }); }
+          } else {
+            or.push({ [f]: { $regex: escaped, $options: 'i' } });
+          }
+        }
+        if (!or.length) { continue; }
+        let docs = await collection.find({ $or: or }).limit(inputs.limit).toArray();
         if (docs.length) {
           groups.push({
             model: cfg.model,

--- a/views/pages/dashboard.ejs
+++ b/views/pages/dashboard.ejs
@@ -124,6 +124,19 @@
           <div class="card-header">
             <h3 class="card-title">Bandwidth</h3>
             <%- partial('../layouts/partials/cardtools.ejs') %>
+            <div class="row">
+              <div class="col-12">
+                <a href="#" class="bwTimeFilters active" seconds="120">2 Minutes</a>
+                &nbsp;&nbsp;
+                <a href="#" class="bwTimeFilters" seconds="300">5 Minutes</a>
+                &nbsp;&nbsp;
+                <a href="#" class="bwTimeFilters" seconds="600">10 Minutes</a>
+                &nbsp;&nbsp;
+                <a href="#" class="bwTimeFilters" seconds="1800">30 Minutes</a>
+                &nbsp;&nbsp;
+                <a href="#" class="bwTimeFilters" seconds="3600">1 Hour</a>
+              </div>
+            </div>
           </div>
           <div class="card-body">
             <div class="chart-responsive">

--- a/views/pages/partials/dashboard.js
+++ b/views/pages/partials/dashboard.js
@@ -132,18 +132,25 @@
 
   if ($('#taskHistory').length) getTInterval();
 
-  // Bandwidth (category x-axis)
+  // Bandwidth: poll live interface stats into a rolling buffer and DISPLAY only
+  // the selected window. We retain up to the largest selectable window (1 hour)
+  // regardless of what's shown, so switching to a longer range instantly shows
+  // the history we already collected instead of starting over from the smaller
+  // window's oldest point. Purely client-side (matches the 1.x 2m/5m/10m/30m/1h).
+  let BANDWIDTH_MAX_RETAIN_SEC = 3600;
   let bandwidthChart,
-    bandwidthChartData,
+    bandwidthSamples = [],      // {t, label, rx, tx}; retained up to MAX_RETAIN
+    bandwidthIface = '',
+    bandwidthWindowSec = 120,   // selected DISPLAY window (default: 2 minutes)
     bandwidthinterval,
     bandwidthajax;
 
-  function bandwidthCanvas() {
+  function bandwidthCanvas(data) {
     let bandwidth = $('#bandwidth').get(0);
     if (!bandwidth) return;
     bandwidthChart = new Chart(bandwidth.getContext('2d'), {
       type: 'line',
-      data: bandwidthChartData,
+      data: data,
       options: {
         responsive: true,
         maintainAspectRatio: false,
@@ -153,14 +160,28 @@
     });
   }
 
-  function addBandwidthData(chart, label, values) {
-    chart.data.labels.push(label);
-    chart.data.datasets.forEach((dataset, i) => dataset.data.push(values[i]));
-    if (chart.data.labels.length > 30) {
-      chart.data.labels.shift();
-      chart.data.datasets.forEach((dataset) => dataset.data.shift());
+  // Show only the samples inside the selected window; the rest stay buffered for
+  // when a longer window is picked. Creates the chart on first render.
+  function renderBandwidth(now) {
+    let cutoff = now - bandwidthWindowSec * 1000,
+      view = bandwidthSamples.filter((s) => s.t >= cutoff),
+      labels = view.map((s) => s.label),
+      rx = view.map((s) => s.rx),
+      tx = view.map((s) => s.tx);
+    if (!bandwidthChart) {
+      bandwidthCanvas({
+        labels: labels,
+        datasets: [
+          { label: bandwidthIface + ' RX (Mbps)', data: rx, fill: false, borderColor: '#3c8dbc', tension: 0.3 },
+          { label: bandwidthIface + ' TX (Mbps)', data: tx, fill: false, borderColor: '#00a65a', tension: 0.3 }
+        ]
+      });
+    } else {
+      bandwidthChart.data.labels = labels;
+      bandwidthChart.data.datasets[0].data = rx;
+      bandwidthChart.data.datasets[1].data = tx;
+      bandwidthChart.update('none');
     }
-    chart.update('none');
   }
 
   function updateBandwidth() {
@@ -176,21 +197,15 @@
           // (si's first sample can be -1; treat anything not > 0 as 0.)
           let stat = series.netstats[0],
             toMbps = function(bps) { return (typeof bps === 'number' && bps > 0) ? Math.round((bps * 8 / 1e6) * 100) / 100 : 0; },
-            label = new Date().toLocaleTimeString(),
-            rx = toMbps(stat.rx_sec),
-            tx = toMbps(stat.tx_sec);
-          if (!bandwidthChart) {
-            bandwidthChartData = {
-              labels: [label],
-              datasets: [
-                { label: stat.iface + ' RX (Mbps)', data: [rx], fill: false, borderColor: '#3c8dbc', tension: 0.3 },
-                { label: stat.iface + ' TX (Mbps)', data: [tx], fill: false, borderColor: '#00a65a', tension: 0.3 }
-              ]
-            };
-            bandwidthCanvas();
-          } else {
-            addBandwidthData(bandwidthChart, label, [rx, tx]);
+            now = Date.now();
+          bandwidthIface = stat.iface;
+          bandwidthSamples.push({ t: now, label: new Date(now).toLocaleTimeString(), rx: toMbps(stat.rx_sec), tx: toMbps(stat.tx_sec) });
+          // Trim the buffer to the largest window so memory stays bounded.
+          let retainCutoff = now - BANDWIDTH_MAX_RETAIN_SEC * 1000;
+          while (bandwidthSamples.length && bandwidthSamples[0].t < retainCutoff) {
+            bandwidthSamples.shift();
           }
+          renderBandwidth(now);
         },
         complete: function() {
           bandwidthinterval = setTimeout(fetchData, 2000);
@@ -200,5 +215,20 @@
     fetchData();
   }
 
-  if ($('#bandwidth').length) updateBandwidth();
+  // Time-range buttons: change the DISPLAY window and re-slice the retained
+  // buffer immediately, so a longer range shows existing history with no wait
+  // and no data loss when growing the window.
+  $('.bwTimeFilters').on('click', function(e) {
+    e.preventDefault();
+    $('.bwTimeFilters.active').removeClass('active');
+    $(this).addClass('active');
+    bandwidthWindowSec = Number($(this).attr('seconds')) || bandwidthWindowSec;
+    if (bandwidthChart) renderBandwidth(Date.now());
+  });
+
+  if ($('#bandwidth').length) {
+    let activeWindow = Number($('.bwTimeFilters.active').attr('seconds'));
+    if (activeWindow) bandwidthWindowSec = activeWindow;
+    updateBandwidth();
+  }
 })(jQuery);


### PR DESCRIPTION
## What & why

Two dashboard/search consistency improvements that bring fog-node closer to the 1.x PHP UI, per maintainer request.

### 1. Universal search now matches host hardware identifiers + tags
Previously hosts only matched on `name`/`description`/`ip`, so pasting a MAC or serial — or typing a tag — wouldn't surface the host. Now host search also covers:

- **`macs`** — query is separator-normalized before matching the bare-hex array, so `aa:bb:cc:dd:ee:ff`, `AA-BB-CC`, and `aabbcc` all match (full or partial). A query that strips to empty (e.g. a lone `:`) is skipped so it can't match every host.
- **`serial`, `asset`, `guid`** — case-insensitive substring match.
- **`tags`** — case-insensitive substring against the tag array, giving partial-tag matches for free.

Other models and permission gating are unchanged.

### 2. Bandwidth chart time-range selector
Adds the 1.x time-range buttons (**2m / 5m / 10m / 30m / 1h**, default 2m) to the Bandwidth card. Purely client-side (no backend/persistence change), but improved over 1.x: samples poll into a **rolling buffer retained up to 1 hour** while only the selected window is *displayed*. Switching to a longer range instantly shows the history already collected, instead of restarting from the shorter window's oldest point. Buffer is trimmed to 1 hour to bound memory.

## Verification
Ran against a live FOG DB through the real `globalSearch` helper:
- MAC (colon/hyphen/uppercase/bare, full + partial), name regression, lone-separator guard — **7/7**
- serial (case-insensitive), asset, guid via a temp host (inserted + deleted, 0 leftover) — **4/4**
- tags (partial/full/hyphenated/case-insensitive/mid-string + non-match) — **6/6**
- Bandwidth buffer/slice logic (window shrink/grow, switch-up history recovery, memory cap) — **7/7**
- Loaded the dashboard on a spare port and eyeballed the chart + search live.

Note: `npm run lint` is currently broken repo-wide on `master` (ESLint was bumped to 10.x, which dropped legacy `.eslintrc` support and needs a flat `eslint.config.js`) — unrelated to this change; files were syntax-checked directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
