### PR TITLE
feat(auth): per-user API bearer token + admin/self password reset

### DIFF
--- a/api/controllers/account/change-password.js
+++ b/api/controllers/account/change-password.js
@@ -1,0 +1,28 @@
+const bcrypt = require('bcryptjs');
+module.exports = {
+  friendlyName: 'Change password',
+  description: 'Logged-in user changes their own password (verifies the current one first). Never via an API token.',
+  inputs: {
+    currentPassword: { type: 'string', required: true },
+    password: { type: 'string', required: true, minLength: 8 },
+    passwordConfirm: { type: 'string', required: true }
+  },
+  exits: {
+    success: {},
+    forbidden: { responseType: 'forbidden' },
+    badRequest: { responseType: 'badRequest' }
+  },
+  fn: async function (inputs, exits) {
+    let req = this.req;
+    if (req.authVia === 'apitoken') return exits.forbidden();
+    if (!req.user) return exits.forbidden();
+    if (inputs.password !== inputs.passwordConfirm) return exits.badRequest({ message: 'New passwords do not match.' });
+    // req.user is sanitized (no password hash) -> re-fetch the record to verify.
+    let me = await User.findOne({ id: req.user.id });
+    if (!me) return exits.forbidden();
+    let match = await bcrypt.compare(inputs.currentPassword, me.password);
+    if (!match) return exits.badRequest({ message: 'Current password is incorrect.' });
+    await User.updateOne({ id: me.id }).set({ password: inputs.password });
+    return exits.success({ ok: true });
+  }
+};

--- a/api/controllers/account/reset-api-token.js
+++ b/api/controllers/account/reset-api-token.js
@@ -1,0 +1,18 @@
+const crypto = require('crypto');
+module.exports = {
+  friendlyName: 'Reset my API token',
+  description: 'Logged-in user (re)generates their own API token. Returns it once; only its SHA-256 is stored.',
+  exits: {
+    success: {},
+    forbidden: { responseType: 'forbidden' }
+  },
+  fn: async function (inputs, exits) {
+    let req = this.req;
+    if (req.authVia === 'apitoken') return exits.forbidden();
+    if (!req.user) return exits.forbidden();
+    let token = 'fpat_' + crypto.randomBytes(24).toString('hex'),
+      hash = crypto.createHash('sha256').update(token).digest('hex');
+    await User.updateOne({ id: req.user.id }).set({ apiTokenHash: hash });
+    return exits.success({ ok: true, token });
+  }
+};

--- a/api/controllers/general/create.js
+++ b/api/controllers/general/create.js
@@ -19,8 +19,10 @@ module.exports = {
     let req = this.req,
       res = this.res,
       params = req.allParams(),
-      model = params.model,
-      obj = await sails.models[model].create(params)
+      model = params.model;
+    // API-token requests may never write credentials (password / apiTokenHash).
+    if (req.authVia === 'apitoken') { delete params.password; delete params.apiTokenHash; }
+    let obj = await sails.models[model].create(params)
       .intercept('E_UNIQUE', (err) => {
         return {conflict: {message: 'A record already exists with that name'}};
       })

--- a/api/controllers/general/save.js
+++ b/api/controllers/general/save.js
@@ -35,6 +35,9 @@ module.exports = {
     // Build the values from the body, dropping non-attribute keys.
     let values = _.omit(req.allParams(), ['model', '_csrf', 'id', '__primac']);
 
+    // API-token requests may never write credentials (password / apiTokenHash).
+    if (req.authVia === 'apitoken') { delete values.password; delete values.apiTokenHash; }
+
     // Drop empty strings from array fields (e.g. blank rows in the MAC widget),
     // so the primary (index 0) is never an empty value.
     _.forEach(values, (v, k) => {

--- a/api/controllers/general/update.js
+++ b/api/controllers/general/update.js
@@ -20,8 +20,10 @@ module.exports = {
       res = this.res,
       params = req.allParams(),
       model = params.model,
-      id = params.id,
-      orig = [],
+      id = params.id;
+    // API-token requests may never write credentials (password / apiTokenHash).
+    if (req.authVia === 'apitoken') { delete params.password; delete params.apiTokenHash; }
+    let orig = [],
       toRem = [],
       obj = await sails.models[model].updateOne({id}, params)
       .intercept('E_UNIQUE', (err) => {

--- a/api/controllers/pages/account.js
+++ b/api/controllers/pages/account.js
@@ -1,0 +1,17 @@
+module.exports = {
+  friendlyName: 'Account',
+  description: 'Self-service account page: change own password and manage own API token.',
+  exits: {
+    success: { viewTemplatePath: 'pages/account' }
+  },
+  fn: async function () {
+    let req = this.req;
+    return {
+      header: 'My Account',
+      title: 'My Account',
+      username: req.user.username,
+      displayName: req.user.displayName || req.user.username,
+      partialname: false
+    };
+  }
+};

--- a/api/controllers/pages/edit.js
+++ b/api/controllers/pages/edit.js
@@ -120,6 +120,9 @@ module.exports = {
         Save: { classes: ['btn-success', 'float-end'], type: 'submit' }
       }
     });
+    // The user edit page gets an admin credential panel (reset password /
+    // regenerate API token) rendered by pages/create.ejs.
+    if (model === 'user') { data.credentialPanel = { userId: String(id) }; }
     return data;
   }
 };

--- a/api/controllers/user/reset-api-token.js
+++ b/api/controllers/user/reset-api-token.js
@@ -1,0 +1,25 @@
+const crypto = require('crypto');
+module.exports = {
+  friendlyName: 'Reset API token',
+  description: "Admin: (re)generate another user's API token. Returns the new token once; only its SHA-256 is stored. Web session only.",
+  inputs: {
+    id: { type: 'string', required: true, description: 'Target user id.' }
+  },
+  exits: {
+    success: { description: 'New token issued.' },
+    forbidden: { responseType: 'forbidden' },
+    notFound: { responseType: 'notFound' }
+  },
+  fn: async function (inputs, exits) {
+    let req = this.req;
+    if (req.authVia === 'apitoken') return exits.forbidden();
+    if (!_.get(req, 'user.permissions.stock.user.update')) return exits.forbidden();
+    let target = await User.findOne({ id: inputs.id });
+    if (!target) return exits.notFound();
+    let token = 'fpat_' + crypto.randomBytes(24).toString('hex'),
+      hash = crypto.createHash('sha256').update(token).digest('hex');
+    await User.updateOne({ id: inputs.id }).set({ apiTokenHash: hash });
+    // The plaintext token is returned exactly once; we keep only the hash.
+    return exits.success({ ok: true, token });
+  }
+};

--- a/api/controllers/user/reset-password.js
+++ b/api/controllers/user/reset-password.js
@@ -1,0 +1,27 @@
+module.exports = {
+  friendlyName: 'Reset password',
+  description: "Admin: set a new password for another user. Web session only -- never via an API token.",
+  inputs: {
+    id: { type: 'string', required: true, description: 'Target user id.' },
+    password: { type: 'string', required: true, minLength: 8 },
+    passwordConfirm: { type: 'string', required: true }
+  },
+  exits: {
+    success: { description: 'Password reset.' },
+    forbidden: { responseType: 'forbidden' },
+    notFound: { responseType: 'notFound' },
+    badRequest: { responseType: 'badRequest' }
+  },
+  fn: async function (inputs, exits) {
+    let req = this.req;
+    // Password changes are never permitted over an API token.
+    if (req.authVia === 'apitoken') return exits.forbidden();
+    if (!_.get(req, 'user.permissions.stock.user.update')) return exits.forbidden();
+    if (inputs.password !== inputs.passwordConfirm) return exits.badRequest({ message: 'Passwords do not match.' });
+    let target = await User.findOne({ id: inputs.id });
+    if (!target) return exits.notFound();
+    // The model's beforeUpdate hook hashes the new password.
+    await User.updateOne({ id: inputs.id }).set({ password: inputs.password });
+    return exits.success({ ok: true });
+  }
+};

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -55,6 +55,11 @@ module.exports = {
       required: true,
       minLength: 8
     },
+    apiTokenHash: {
+      type: 'string',
+      allowNull: true,
+      description: 'SHA-256 of the user\'s API bearer token. The token itself is never stored.'
+    },
     roles: {
       collection: 'role',
       via: 'users'
@@ -82,7 +87,7 @@ module.exports = {
       return permissions;
     };
     this.permissions = concatRoles(this.roles);
-    return _.omit(this, ['password','roles']);
+    return _.omit(this, ['password','roles','apiTokenHash']);
   },
   beforeCreate: function(values, next) {
     bcrypt.hash(values.password, sails.config.auth.bcrypt.rounds, (err, hash) => {

--- a/api/policies/isLoggedIn.js
+++ b/api/policies/isLoggedIn.js
@@ -1,14 +1,32 @@
-const passport = require('passport');
+const passport = require('passport'),
+  crypto = require('crypto');
+
 module.exports = async (req, res, next) => {
+  // 1) Opaque per-user API token: `Authorization: Bearer fpat_<token>`.
+  //    Long-lived and independently resettable, distinct from the short-lived
+  //    login JWT. We store only the SHA-256, so hash the presented token and
+  //    look the user up by it. Tag the request so credential writes (password,
+  //    token) can be refused for API clients (see general/create|update|save).
+  let authHeader = req.headers && req.headers.authorization,
+    m = authHeader && /^Bearer\s+(fpat_[A-Za-z0-9]+)$/.exec(authHeader);
+  if (m) {
+    let hash = crypto.createHash('sha256').update(m[1]).digest('hex'),
+      user = await User.findOne({ apiTokenHash: hash }).populateAll();
+    if (user) {
+      req.authVia = 'apitoken';
+      return req.login(user.toJSON(), { session: false }, (err) => err ? next(err) : next());
+    }
+    // Unknown token: fall through unauthenticated -> isAuthenticated will 403.
+  }
+
+  // 2) Session / JWT (cookie or bearer) auth -- existing behaviour.
   try {
-    await passport.authenticate(sails.config.globals.jwtAuthMechanisms, {session: false}, async (err, user, info) => {
+    await passport.authenticate(sails.config.globals.jwtAuthMechanisms, { session: false }, async (err, user) => {
       if (err) return next(err);
       if (!user) return next();
+      req.authVia = 'session';
       user = user.toJSON();
-      await req.login(user, async (err) => {
-        if (err) return next(err);
-        next();
-      });
+      await req.login(user, async (err) => err ? next(err) : next());
     })(req, res);
   } catch (e) {
     next();

--- a/api/policies/stripApiTokenCredentials.js
+++ b/api/policies/stripApiTokenCredentials.js
@@ -1,0 +1,21 @@
+/**
+ * Defence-in-depth: a request authenticated by an API token (Bearer fpat_...)
+ * may NEVER write credentials -- the password or the API token hash -- through
+ * ANY route, including Sails blueprint REST/shortcut routes that bypass the
+ * per-action guards. Strip those fields from the request before the action runs.
+ *
+ * Credential changes are only possible through the dedicated, web-session-only
+ * endpoints (user/reset-password, account/change-password, *.reset-api-token),
+ * which additionally refuse API-token auth outright.
+ */
+module.exports = async (req, res, next) => {
+  if (req.authVia === 'apitoken') {
+    for (let bag of [req.body, req.query]) {
+      if (bag && typeof bag === 'object') {
+        delete bag.password;
+        delete bag.apiTokenHash;
+      }
+    }
+  }
+  return next();
+};

--- a/config/policies.js
+++ b/config/policies.js
@@ -36,6 +36,11 @@ module.exports.policies = {
 
   // User Policies
   'user/listme':           ['isLoggedIn','isAuthenticated'],
+  // Credential management (each action self-checks permission + refuses API-token auth)
+  'user/reset-password':     ['isLoggedIn','isAuthenticated'],
+  'user/reset-api-token':    ['isLoggedIn','isAuthenticated'],
+  'account/change-password': ['isLoggedIn','isAuthenticated'],
+  'account/reset-api-token': ['isLoggedIn','isAuthenticated'],
 
   // Auth Policies
   'auth/login':            'isNotLoggedIn',
@@ -44,7 +49,7 @@ module.exports.policies = {
 
   'pages/login':           'isNotLoggedIn',
 
-  '*':                     ['isLoggedIn','isAuthenticated'],
+  '*':                     ['isLoggedIn','isAuthenticated','stripApiTokenCredentials'],
 
   // Allow API Backend to work
   'api':                   true,

--- a/config/routes.js
+++ b/config/routes.js
@@ -137,6 +137,15 @@ module.exports.routes = {
   'POST /users/create':                      {action: 'general/save'},
   'GET /user/me':                            {action: 'user/listme'},
 
+  // User credential management (admin; web session only -- never via API token)
+  'POST /users/:id/reset-password':          {action: 'user/reset-password'},
+  'POST /users/:id/api-token':               {action: 'user/reset-api-token'},
+
+  // Self-service account credential management (logged-in user, own credentials)
+  'GET /account':                            {action: 'pages/account'},
+  'POST /account/password':                  {action: 'account/change-password'},
+  'POST /account/api-token':                 {action: 'account/reset-api-token'},
+
   // Workflow Views
   'GET /workflows':                          {action: 'pages/list/workflows'},
 

--- a/views/layouts/partials/rightnavbar-links.ejs
+++ b/views/layouts/partials/rightnavbar-links.ejs
@@ -7,6 +7,11 @@
     </a>
   </li>
   <li class="nav-item">
+    <a class="nav-link" href="/account">
+      <i class="fa fa-key"></i> Account
+    </a>
+  </li>
+  <li class="nav-item">
     <a class="nav-link" href="/logout">
       <i class="fa fa-sign-out"></i> Logout
     </a>

--- a/views/pages/account.ejs
+++ b/views/pages/account.ejs
@@ -1,0 +1,72 @@
+<div class="app-content-header">
+  <div class="container-fluid">
+    <div class="col-sm-6"><h3 class="mb-0"><%= header %></h3></div>
+  </div>
+</div>
+<div class="app-content">
+  <div class="container-fluid">
+    <div class="row"><div class="col-md-8">
+      <div class="card card-primary card-outline">
+        <div class="card-header"><h3 class="card-title">Change my password</h3></div>
+        <div class="card-body">
+          <div class="mb-2">
+            <label class="form-label" for="ac-cur">Current password</label>
+            <input type="password" id="ac-cur" class="form-control" autocomplete="current-password">
+          </div>
+          <div class="mb-2">
+            <label class="form-label" for="ac-pw">New password</label>
+            <input type="password" id="ac-pw" class="form-control" minlength="8" autocomplete="new-password">
+          </div>
+          <div class="mb-2">
+            <label class="form-label" for="ac-pwc">Confirm new password</label>
+            <input type="password" id="ac-pwc" class="form-control" autocomplete="new-password">
+          </div>
+          <button id="ac-btn" type="button" class="btn btn-primary">Change password</button>
+          <div id="ac-msg" class="mt-2"></div>
+        </div>
+      </div>
+
+      <div class="card card-info card-outline">
+        <div class="card-header"><h3 class="card-title">My API token</h3></div>
+        <div class="card-body">
+          <p class="text-muted mb-2">Use as <code>Authorization: Bearer &lt;token&gt;</code> for API access. Regenerating invalidates the previous token immediately; the new token is shown only once. An API token can never change a password.</p>
+          <button id="ac-tok" type="button" class="btn btn-info">Regenerate my API token</button>
+          <div id="ac-tokmsg" class="mt-2"></div>
+        </div>
+      </div>
+    </div></div>
+  </div>
+</div>
+<script>
+(function(){
+  function post(url, body){
+    return fetch(url, {method:'POST', credentials:'same-origin',
+      headers:{'Content-Type':'application/json','Accept':'application/json'},
+      body: body ? JSON.stringify(body) : undefined});
+  }
+  function show(el, ok, html){ el.className = 'mt-2 alert ' + (ok ? 'alert-success' : 'alert-danger'); el.innerHTML = html; }
+  document.getElementById('ac-btn').addEventListener('click', async function(){
+    var cur = document.getElementById('ac-cur').value,
+      pw = document.getElementById('ac-pw').value,
+      pwc = document.getElementById('ac-pwc').value,
+      m = document.getElementById('ac-msg');
+    if (pw.length < 8) { return show(m, false, 'New password must be at least 8 characters.'); }
+    if (pw !== pwc) { return show(m, false, 'New passwords do not match.'); }
+    try {
+      var r = await post('/account/password', {currentPassword: cur, password: pw, passwordConfirm: pwc});
+      if (r.ok) { show(m, true, 'Password changed.'); document.getElementById('ac-cur').value=''; document.getElementById('ac-pw').value=''; document.getElementById('ac-pwc').value=''; }
+      else { var j = await r.json().catch(function(){return {};}); show(m, false, (j.message || ('Failed (HTTP ' + r.status + ')'))); }
+    } catch (e) { show(m, false, 'Request failed.'); }
+  });
+  document.getElementById('ac-tok').addEventListener('click', async function(){
+    var m = document.getElementById('ac-tokmsg');
+    try {
+      var r = await post('/account/api-token');
+      if (r.ok) { var j = await r.json(); show(m, true, 'New API token (copy now &mdash; shown once):<br><code style="word-break:break-all">' + j.token + '</code>'); }
+      else { show(m, false, 'Failed (HTTP ' + r.status + ')'); }
+    } catch (e) { show(m, false, 'Request failed.'); }
+  });
+})();
+</script>
+
+<%- /* Expose server-rendered data as window.SAILS_LOCALS :: */ exposeLocalsToBrowser() %>

--- a/views/pages/create.ejs
+++ b/views/pages/create.ejs
@@ -28,4 +28,67 @@
   </div>
 </div>
 
+<% if (typeof credentialPanel !== 'undefined' && credentialPanel) { %>
+<div class="app-content">
+  <div class="container-fluid">
+    <div class="row"><div class="col-12">
+      <div class="card card-warning card-outline">
+        <div class="card-header"><h3 class="card-title">Credentials</h3></div>
+        <div class="card-body">
+          <h5>Reset password</h5>
+          <div class="row g-2 align-items-end">
+            <div class="col-md-4">
+              <label class="form-label" for="cp-pw">New password</label>
+              <input type="password" id="cp-pw" class="form-control" minlength="8" autocomplete="new-password">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label" for="cp-pwc">Confirm password</label>
+              <input type="password" id="cp-pwc" class="form-control" autocomplete="new-password">
+            </div>
+            <div class="col-md-3">
+              <button id="cp-btn" type="button" class="btn btn-warning">Reset password</button>
+            </div>
+          </div>
+          <div id="cp-msg" class="mt-2"></div>
+          <hr>
+          <h5>API token</h5>
+          <p class="text-muted mb-2">Used as <code>Authorization: Bearer &lt;token&gt;</code> for API access. Regenerating immediately invalidates the previous token; the new token is shown only once. API tokens can never change a password.</p>
+          <button id="tok-btn" type="button" class="btn btn-info">Regenerate API token</button>
+          <div id="tok-msg" class="mt-2"></div>
+        </div>
+      </div>
+    </div></div>
+  </div>
+</div>
+<script>
+(function(){
+  var uid = <%- JSON.stringify(credentialPanel.userId) %>;
+  function post(url, body){
+    return fetch(url, {method:'POST', credentials:'same-origin',
+      headers:{'Content-Type':'application/json','Accept':'application/json'},
+      body: body ? JSON.stringify(body) : undefined});
+  }
+  function show(el, ok, html){ el.className = 'mt-2 alert ' + (ok ? 'alert-success' : 'alert-danger'); el.innerHTML = html; }
+  document.getElementById('cp-btn').addEventListener('click', async function(){
+    var pw = document.getElementById('cp-pw').value, pwc = document.getElementById('cp-pwc').value, m = document.getElementById('cp-msg');
+    if (pw.length < 8) { return show(m, false, 'Password must be at least 8 characters.'); }
+    if (pw !== pwc) { return show(m, false, 'Passwords do not match.'); }
+    try {
+      var r = await post('/users/' + uid + '/reset-password', {password: pw, passwordConfirm: pwc});
+      if (r.ok) { show(m, true, 'Password reset.'); document.getElementById('cp-pw').value = ''; document.getElementById('cp-pwc').value = ''; }
+      else { var j = await r.json().catch(function(){return {};}); show(m, false, (j.message || ('Failed (HTTP ' + r.status + ')'))); }
+    } catch (e) { show(m, false, 'Request failed.'); }
+  });
+  document.getElementById('tok-btn').addEventListener('click', async function(){
+    var m = document.getElementById('tok-msg');
+    try {
+      var r = await post('/users/' + uid + '/api-token');
+      if (r.ok) { var j = await r.json(); show(m, true, 'New API token (copy now &mdash; shown once):<br><code style="word-break:break-all">' + j.token + '</code>'); }
+      else { show(m, false, 'Failed (HTTP ' + r.status + ')'); }
+    } catch (e) { show(m, false, 'Request failed.'); }
+  });
+})();
+</script>
+<% } %>
+
 <%- /* Expose server-rendered data as window.SAILS_LOCALS :: */ exposeLocalsToBrowser() %>


### PR DESCRIPTION
## Summary

Credential management for users, with a clean **web-session vs API-token** trust split.

### Per-user API token
- Opaque token `fpat_<48 hex>`, presented as `Authorization: Bearer <token>`. **Only its SHA-256 is stored** (`apiTokenHash` on `User`, stripped from `toJSON`).
- `isLoggedIn` recognises it, authenticates as that user (with their permissions), and tags `req.authVia = 'apitoken'`.
- **Regenerate** issues a new token (returned **once**) and instantly revokes the old one — resettable without touching the password.

### Password reset
- **Admin** resets any user from the user **edit page** (gated by the `user.update` permission).
- **Self-service**: users change their own password (verifying the current one) on a new **/account** page (navbar link).
- Both are **web-session only**.

### Hard rule: an API token can NEVER change a password
1. The dedicated credential endpoints refuse `req.authVia === 'apitoken'` (403).
2. A global `stripApiTokenCredentials` policy removes `password`/`apiTokenHash` from **any** token-authed write — closing the Sails **blueprint REST/shortcut bypass** (`rest`/`shortcuts` are on).

## Files
New actions: `user/reset-password`, `user/reset-api-token`, `account/change-password`, `account/reset-api-token`, `pages/account`. New policy: `stripApiTokenCredentials`. Model: `apiTokenHash`. Guards in `general/create|update|save`. UI: credential panel on the user edit page + the Account page.

## Verification (throwaway lift, isolated port) — 10/10
- bearer token authenticates as the user; **cannot** change a password via blueprint `PUT` or `GET …/update/:id?password=` (both stripped); credential endpoints return 403 under token auth; admin reset + self change + self token-reset all succeed; both pages render (HTTP 200, no EJS errors).

## Notes / follow-ups
- CSRF is disabled app-wide (pre-existing), so these POSTs need no token; worth enabling separately.
- Sails **blueprints expose unauthorized model CRUD** (`rest`/`shortcuts` bypass the permission policies) — pre-existing, broader than this PR; flagged for a separate hardening pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)