### PR TITLE
feat(ui): searchable select2 dropdowns across the app

### DIFF
--- a/assets/fog/fog.select2.js
+++ b/assets/fog/fog.select2.js
@@ -1,0 +1,50 @@
+/**
+ * fog.select2.js
+ *
+ * Turn every <select> into a searchable, consistently-styled select2 control,
+ * so dropdowns look and behave the same throughout the UI. Idempotent, and
+ * re-runs for dynamically-added content: the shared create/edit modal and
+ * DataTables' "Show N entries" length menu.
+ *
+ * Opt a single select out with `data-no-select2`.
+ */
+(function($) {
+  function initSelect2(context, dropdownParent) {
+    if (!$.fn.select2) { return; } // lib not loaded -> leave native selects
+    $(context || document).find('select').each(function() {
+      var $sel = $(this);
+      if ($sel.hasClass('select2-hidden-accessible')) { return; } // already enhanced
+      if ($sel.is('[data-no-select2]')) { return; }               // explicit opt-out
+
+      var opts = { width: '100%' };
+      // DataTables' length menu is tiny (10/25/50/100); size it to its content
+      // instead of stretching it across the toolbar.
+      if ($sel.closest('.dt-length, .dataTables_length').length) {
+        opts.width = 'auto';
+      }
+      // Inside a Bootstrap modal, render the dropdown within the modal so it
+      // keeps search-box focus and stacks above the backdrop.
+      if (dropdownParent && dropdownParent.length) {
+        opts.dropdownParent = dropdownParent;
+      }
+      $sel.select2(opts);
+    });
+  }
+
+  // Initial page load (covers full-page forms and any selects already present).
+  $(function() { initSelect2(document); });
+
+  // The shared entity create/edit modal lazy-loads a server-rendered form;
+  // enhance its selects once the modal has finished opening.
+  $(document).on('shown.bs.modal', function(e) {
+    initSelect2(e.target, $(e.target));
+  });
+
+  // DataTables builds its length <select> after the table initializes.
+  $(document).on('init.dt', function(e, settings) {
+    initSelect2(settings.nTableWrapper || document);
+  });
+
+  // Let code that injects its own selects re-run the same enhancement.
+  window.fogInitSelect2 = initSelect2;
+})(jQuery);

--- a/assets/styles/zz-fog-select2.css
+++ b/assets/styles/zz-fog-select2.css
@@ -1,0 +1,71 @@
+/*
+ * zz-fog-select2.css
+ *
+ * Align select2 (stock "default" theme) with Bootstrap 5 / AdminLTE 4 form
+ * controls so searchable dropdowns match the native inputs around them. We use
+ * the stock theme + this shim on purpose rather than pulling an npm BS5-theme
+ * package (that would disturb the AdminLTE asset lockfile).
+ *
+ * The `zz-` filename prefix is deliberate: assets/styles is auto-injected
+ * alphabetically, and this must load AFTER select2's own base stylesheet
+ * (styles/select2/dist/css/...) to win the cascade.
+ *
+ * BS5 CSS variables are used (with light-mode fallbacks) so the control follows
+ * AdminLTE's light/dark theme.
+ */
+
+/* Never let a select2 control or its body-appended dropdown exceed the parent,
+   so an open dropdown can't stretch the page sideways. The width itself comes
+   from select2's width:'100%' init option (set literally, so selects in a
+   not-yet-shown tab still size correctly when revealed). */
+.select2-container { max-width: 100%; box-sizing: border-box; }
+
+.select2-container--default .select2-selection--single {
+  height: calc(1.5em + 0.75rem + 2px);
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--bs-border-color, #ced4da);
+  border-radius: 0.375rem;
+  background-color: var(--bs-body-bg, #fff);
+}
+
+.select2-container--default .select2-selection--single .select2-selection__rendered {
+  line-height: 1.5;
+  padding-left: 0;
+  padding-right: 1.25rem;
+  color: var(--bs-body-color, #212529);
+}
+
+.select2-container--default .select2-selection--single .select2-selection__arrow {
+  height: 100%;
+  top: 0;
+  right: 0.5rem;
+}
+
+.select2-container--default.select2-container--focus .select2-selection--single,
+.select2-container--default.select2-container--open .select2-selection--single {
+  border-color: #86b7fe;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+  outline: 0;
+}
+
+/* Dropdown panel + search field. */
+.select2-dropdown {
+  border-color: #86b7fe;
+  background-color: var(--bs-body-bg, #fff);
+  color: var(--bs-body-color, #212529);
+}
+.select2-search--dropdown .select2-search__field {
+  border: 1px solid var(--bs-border-color, #ced4da);
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
+}
+.select2-container--default .select2-results__option--highlighted[aria-selected] {
+  background-color: var(--bs-primary, #0d6efd);
+}
+
+/* Stack above Bootstrap 5 modals (modal sits at z-index 1055). */
+.select2-container { z-index: 1056; }
+
+/* Keep the DataTables length menu from collapsing too narrow. */
+.dt-length .select2-container,
+.dataTables_length .select2-container { min-width: 5rem; }

--- a/views/layouts/layout.ejs
+++ b/views/layouts/layout.ejs
@@ -57,6 +57,8 @@
     <link rel="stylesheet" href="/styles/icheck-bootstrap/icheck-bootstrap.min.css">
     <link rel="stylesheet" href="/styles/importer.css">
     <link rel="stylesheet" href="/styles/pace-js/themes/blue/pace-theme-minimal.css">
+    <link rel="stylesheet" href="/styles/select2/dist/css/select2.min.css">
+    <link rel="stylesheet" href="/styles/zz-fog-select2.css">
     <!--STYLES END-->
   </head>
 
@@ -207,9 +209,11 @@
     <script src="/js/inputmask/dist/jquery.inputmask.min.js"></script>
     <script src="/js/jszip/dist/jszip.min.js"></script>
     <script src="/js/pdfmake/build/pdfmake.min.js"></script>
+    <script src="/js/select2/dist/js/select2.full.min.js"></script>
     <script src="/fog/fog.common.js"></script>
     <script src="/fog/fog.maclist.js"></script>
     <script src="/fog/fog.search.js"></script>
+    <script src="/fog/fog.select2.js"></script>
     <!--SCRIPTS END-->
     <% if (partialname) { %>
     <script type="text/javascript">


### PR DESCRIPTION
## What & why
Make every `<select>` a searchable, consistently-styled **select2** dropdown across the UI, so dropdowns look and behave the same everywhere. Requested for consistency with the rest of the project.

This also puts the previously-orphaned select2 include (the recurring uncommitted `layout.ejs` "churn") to actual use.

## Changes
- **`assets/fog/fog.select2.js`** — global init on every `<select>`. Idempotent; re-runs on `shown.bs.modal` (with `dropdownParent` so the panel stays inside the create/edit modal) and on DataTables `init.dt` (the "Show N entries" menu). Opt a select out with `data-no-select2`.
- **`assets/styles/zz-fog-select2.css`** — aligns the stock select2 theme with Bootstrap 5 / AdminLTE 4 (height, border, focus ring, colors via `--bs-*` vars so it follows light/dark). Uses the stock theme + this shim rather than an npm BS5-theme package, to avoid disturbing the AdminLTE asset lockfile. `max-width:100%` keeps the body-appended dropdown from stretching the page; the `zz-` filename loads it after select2's base CSS.
- **`layout.ejs`** — the grunt sails-linker include tags for the above (and the select2 lib).

## Verification
- Headless-Chrome smoke test against the real built assets: select2 attaches to generated-style selects (incl. one inside a hidden tab), preserves the selected value, respects `data-no-select2`, and produces **no horizontal overflow** (control fills its field, dropdown matches the control).
- Eyeballed live on a spare-port instance (dropdowns searchable; width verified after fix).

Note: `npm run lint` is broken repo-wide (ESLint 10 dropped `.eslintrc`); files were syntax-checked directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
