### PR TITLE
chore(setup): default new installs to migrate:'safe' (prevent data loss)

### DIFF
--- a/tools/setup/dev.js
+++ b/tools/setup/dev.js
@@ -98,7 +98,10 @@ writeIfMissing(localCfg, 'config/local.js', `module.exports = {
 
 writeIfMissing(modelsCfg, 'config/models.js', `module.exports.models = {
   schema: true,
-  migrate: 'alter',
+  // 'safe' = never auto-migrate. Mongo is schemaless so no migration is needed,
+  // and 'alter' can drop/recreate collections (data loss) -- especially with more
+  // than one app instance pointed at the same database.
+  migrate: 'safe',
   attributes: {
     createdAt: { type: 'number', autoCreatedAt: true },
     updatedAt: { type: 'number', autoUpdatedAt: true },

--- a/tools/setup/index.js
+++ b/tools/setup/index.js
@@ -141,7 +141,10 @@ module.exports.http = {
      */
     rawtext = `module.exports.models = {
   schema: true,
-  migrate: 'alter',
+  // 'safe' = never auto-migrate. Mongo is schemaless so no migration is needed,
+  // and 'alter' can drop/recreate collections (data loss) -- especially with more
+  // than one app instance pointed at the same database.
+  migrate: 'safe',
   attributes: {
     createdAt: { type: 'number', autoCreatedAt: true },
     updatedAt: { type: 'number', autoUpdatedAt: true },


### PR DESCRIPTION
`setup:dev` and the interactive installer (`tools/setup/index.js`) generated `config/models.js` with **`migrate: 'alter'`**, which auto-migrates the schema on every lift. On `sails-mongo` that can drop/recreate collections, and **multiple instances against one DB race it → data loss** (this wiped the dev DB during recent work, taking user API tokens with it).

MongoDB is schemaless, so no migration step is needed — default new installs to **`migrate: 'safe'`** (which is also already the setting in `config/env/production.js`).

Note: `config/models.js` is git-ignored, so existing installs keep their current value — those were updated in place separately. This only changes what fresh `setup:dev`/installer runs generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)