### PR TITLE
feat(ui): tag pills + chip input, bulk tag/image modals, dashboard alerts

### DIFF
--- a/api/controllers/host/tags.js
+++ b/api/controllers/host/tags.js
@@ -1,0 +1,36 @@
+/**
+ * host/tags
+ *
+ * Return the distinct set of tags in use across all hosts, sorted
+ * case-insensitively. Feeds the bulk "Manage tags" modal's remove list when the
+ * action targets all hosts matching the current search (no explicit selection to
+ * union tags from). Mirrors host/bulk's inline permission check -- there is no
+ * :model param here for the generic `read` policy to act on.
+ */
+module.exports = {
+  friendlyName: 'List host tags',
+  description: 'Distinct tags used across all hosts.',
+  fn: async function () {
+    let req = this.req,
+      res = this.res;
+
+    if (!_.get(req, 'user.permissions.stock.host.read')) {
+      return res.forbidden();
+    }
+
+    let hosts = await sails.models.host.find().select(['tags']),
+      seen = {},
+      out = [];
+    for (let h of hosts) {
+      if (!Array.isArray(h.tags)) { continue; }
+      for (let t of h.tags) {
+        let tag = String(t).trim();
+        if (!tag) { continue; }
+        let key = tag.toLowerCase();
+        if (!seen[key]) { seen[key] = true; out.push(tag); }
+      }
+    }
+    out.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+    return res.json({ tags: out });
+  }
+};

--- a/api/controllers/pages/create/hosts.js
+++ b/api/controllers/pages/create/hosts.js
@@ -43,10 +43,10 @@ module.exports = {
           tags: {
             textarea: false,
             text: 'Tags',
-            type: 'text',
+            type: 'taginput',
             id: 'hosttags',
             classes: [],
-            placeholder: 'lab-a, win11, 3rd-floor'
+            value: []
           }
         },
         formButtons: {

--- a/api/controllers/pages/dashboard.js
+++ b/api/controllers/pages/dashboard.js
@@ -68,6 +68,9 @@ module.exports = {
       capacity = storageNodes.reduce((sum, n) => sum + (Number(n.maxClients) || 0), 0),
       avail = Math.max(0, capacity - active - staged);
 
+    // Alerts panel (parity with 1.x dashboard): hosts awaiting approval.
+    let pendingHosts = await Host.count({ pending: true });
+
     let data = {
       header: 'Dashboard',
       title: 'Dashboard',
@@ -75,7 +78,8 @@ module.exports = {
       partialname: false,
       free, used, size, legend,
       webserver, loadaverage, uptime,
-      avail, staged, active
+      avail, staged, active,
+      pendingHosts
     };
     let partial = path.join(partialPath, `${data.model}.js`);
     if (fs.existsSync(partial)) {

--- a/api/controllers/pages/edit.js
+++ b/api/controllers/pages/edit.js
@@ -60,13 +60,12 @@ module.exports = {
         return;
       }
 
-      // Tags: a comma-separated text field over the json array.
+      // Tags: a chip/token input over the json array (see fog.taginput.js).
       if (model === 'host' && key === 'tags') {
         let stored = Array.isArray(record[key]) ? record[key] : [];
         formItems[key] = {
           text: 'Tags', id: `${model}-tags`, classes: [], textarea: false,
-          type: 'text', placeholder: 'lab-a, win11, 3rd-floor',
-          value: stored.join(', ')
+          type: 'taginput', value: stored
         };
         return;
       }

--- a/api/helpers/form-generator.js
+++ b/api/helpers/form-generator.js
@@ -120,6 +120,23 @@ module.exports = {
             </div>`;
           return field;
         }
+        case 'taginput': {
+          // Chip/token input; fog.taginput.js builds the chips + hidden field
+          // from data-tags on load. Value may be an array or a comma string.
+          let vals = Array.isArray(input.value)
+            ? input.value
+            : (input.value ? String(input.value).split(/[\n,]+/) : []);
+          let csv = vals.map((t) => String(t).trim()).filter(Boolean).join(',');
+          field += `
+            <div class="row mb-3">
+              <label class="col-sm-2 col-form-label"${iFor}>${input.text}</label>
+              <div class="col-sm-10">
+                <div data-taginput data-name="${item}" data-tags="${csv.replace(/"/g, '&quot;')}"></div>
+                <small class="form-text text-muted">Type a tag and press Enter or comma.</small>
+              </div>
+            </div>`;
+          return field;
+        }
         case 'checktable': {
           field += `
             <div class="row mb-3">

--- a/assets/fog/fog.common.js
+++ b/assets/fog/fog.common.js
@@ -39,7 +39,7 @@ $.fn.registerTable = function(onSelect, opts) {
         action: function(e, dt, node, config) {
           let rows = dt.rows({selected: true}).data().toArray();
           if (rows.length !== 1) {
-            window.alert('Select exactly one row to edit.');
+            window.fogToast('error', 'Select exactly one row to edit.');
             return;
           }
           let base = window.location.pathname.replace(/\/$/, '');
@@ -52,21 +52,26 @@ $.fn.registerTable = function(onSelect, opts) {
         action: function(e, dt, node, config) {
           let ids = dt.rows({selected: true}).data().toArray().map((r) => r.id).filter(Boolean);
           if (!ids.length) {
-            window.alert('Select one or more rows to delete.');
+            window.fogToast('error', 'Select one or more rows to delete.');
             return;
           }
-          if (!window.confirm(`Delete ${ids.length} selected item(s)? This cannot be undone.`)) {
-            return;
-          }
-          let base = dt.ajax.url().replace(/\/datatable.*$/, '');
-          $.ajax({
-            url: base,
-            type: 'DELETE',
-            contentType: 'application/json',
-            data: JSON.stringify({id: ids}),
-            complete: function() {
-              dt.ajax.reload();
-            }
+          window.fogConfirm({
+            title: `Delete ${ids.length} selected item(s)?`,
+            body: 'This cannot be undone.',
+            confirmText: 'Delete',
+            danger: true
+          }).then(function(ok) {
+            if (!ok) { return; }
+            let base = dt.ajax.url().replace(/\/datatable.*$/, '');
+            $.ajax({
+              url: base,
+              type: 'DELETE',
+              contentType: 'application/json',
+              data: JSON.stringify({id: ids}),
+              complete: function() {
+                dt.ajax.reload();
+              }
+            });
           });
         }
       }
@@ -225,4 +230,85 @@ $.readableBytes = function(bytes) {
       })
       .catch(function() { showError(body, 'Could not load the form.'); });
   };
+})();
+
+// Shared UI helpers used to replace native dialogs (alert/confirm/prompt) with
+// AdminLTE/Bootstrap toasts + modals across the lists. Each degrades gracefully
+// when its dependency (PNotify / Bootstrap) is missing.
+(function() {
+  // Toast notification; falls back to alert() if PNotify isn't loaded.
+  function toast(type, text) {
+    try {
+      if (window.PNotify && typeof PNotify.alert === 'function') {
+        PNotify.alert({ type: type === 'error' ? 'error' : type, text: text, delay: 3000 });
+        return;
+      }
+    } catch (e) { /* fall through to native */ }
+    window.alert(text);
+  }
+
+  // Build + show a Bootstrap modal. Returns {el, modal, body} or null (no
+  // Bootstrap). `onConfirm(el, modal)` may return false (keep open) or a promise.
+  function modal(opts) {
+    opts = opts || {};
+    if (!window.bootstrap) { return null; }
+    let wrap = document.createElement('div');
+    wrap.className = 'modal fade';
+    wrap.tabIndex = -1;
+    wrap.innerHTML =
+      '<div class="modal-dialog modal-dialog-centered' + (opts.size ? ' ' + opts.size : '') + '">' +
+        '<div class="modal-content">' +
+          '<div class="modal-header"><h5 class="modal-title"></h5>' +
+            '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>' +
+          '<div class="modal-body"></div>' +
+          '<div class="modal-footer">' +
+            '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">' +
+              (opts.cancelText || 'Cancel') + '</button>' +
+            '<button type="button" class="btn ' + (opts.danger ? 'btn-danger' : 'btn-primary') +
+              '" data-fog-confirm>' + (opts.confirmText || 'OK') + '</button>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+    wrap.querySelector('.modal-title').textContent = opts.title || '';
+    let bodyEl = wrap.querySelector('.modal-body');
+    if (typeof opts.body === 'string') { bodyEl.innerHTML = opts.body; }
+    else if (opts.body instanceof Node) { bodyEl.appendChild(opts.body); }
+    document.body.appendChild(wrap);
+    let m = bootstrap.Modal.getOrCreateInstance(wrap);
+    wrap.addEventListener('hidden.bs.modal', function() { m.dispose(); wrap.remove(); });
+    wrap.querySelector('[data-fog-confirm]').addEventListener('click', function() {
+      let r = opts.onConfirm ? opts.onConfirm(wrap, m) : true;
+      Promise.resolve(r).then(function(keep) { if (keep !== false) { m.hide(); } });
+    });
+    if (opts.onShown) {
+      wrap.addEventListener('shown.bs.modal', function() { opts.onShown(wrap); }, { once: true });
+    }
+    m.show();
+    return { el: wrap, modal: m, body: bodyEl };
+  }
+
+  // Confirm dialog -> Promise<boolean>. Falls back to window.confirm().
+  function confirm(opts) {
+    opts = opts || {};
+    return new Promise(function(resolve) {
+      if (!window.bootstrap) {
+        resolve(window.confirm(opts.body || opts.title || 'Are you sure?'));
+        return;
+      }
+      let answered = false,
+        ctrl = modal({
+          title: opts.title || 'Please confirm',
+          body: '<p class="mb-0">' + (opts.body || '') + '</p>',
+          confirmText: opts.confirmText || 'Confirm',
+          cancelText: opts.cancelText || 'Cancel',
+          danger: opts.danger,
+          onConfirm: function() { answered = true; resolve(true); }
+        });
+      ctrl.el.addEventListener('hidden.bs.modal', function() { if (!answered) { resolve(false); } });
+    });
+  }
+
+  window.fogToast = toast;
+  window.fogModal = modal;
+  window.fogConfirm = confirm;
 })();

--- a/assets/fog/fog.taginput.js
+++ b/assets/fog/fog.taginput.js
@@ -1,0 +1,91 @@
+// Tag (token/chip) input widget for the host create/edit forms and the bulk
+// "Manage tags" modal. A `[data-taginput]` container (rendered server-side by
+// form-generator, or injected by the modal) carries `data-name` + `data-tags`;
+// this builds removable chips plus a text entry and keeps a hidden
+// `<input name="<data-name>">` in sync (comma-joined). The existing form POST
+// and the Host model's tag normalisation then handle it unchanged -- mirrors how
+// fog.maclist.js drives the MAC widget.
+(function($) {
+  function esc(s) {
+    return String(s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+  function chipHtml(tag) {
+    return `<span class="badge bg-primary fog-tag" data-tag="${esc(tag)}">${esc(tag)}` +
+      `<button type="button" class="fog-tag-x" tabindex="-1" aria-label="Remove tag">&times;</button></span>`;
+  }
+  // Current chip values, in display order.
+  function values($root) {
+    return $root.find('.fog-tag').map(function() {
+      return $(this).attr('data-tag');
+    }).get();
+  }
+  // Keep the hidden field (submitted as the model's tag value) in sync.
+  function sync($root) {
+    $root.find('.fog-taginput-value').val(values($root).join(', '));
+  }
+  // Add a chip unless a case-insensitive duplicate already exists.
+  function addTag($root, text) {
+    let tag = $.trim(text || '');
+    if (!tag) { return; }
+    let lower = tag.toLowerCase();
+    if (!values($root).some((t) => t.toLowerCase() === lower)) {
+      $root.find('.fog-taginput-entry').before(chipHtml(tag));
+    }
+    sync($root);
+  }
+  // Turn a bare `[data-taginput]` container into the chips + entry + hidden field.
+  function build($root) {
+    if ($root.data('taginputReady')) { return; }
+    let name = $root.attr('data-name') || 'tags',
+      tags = ($root.attr('data-tags') || '').split(/[\n,]+/).map((t) => $.trim(t)).filter(Boolean);
+    $root.addClass('form-control fog-taginput').html(
+      tags.map(chipHtml).join('') +
+      '<input type="text" class="fog-taginput-entry" autocomplete="off" placeholder="add tag…">' +
+      `<input type="hidden" class="fog-taginput-value" name="${esc(name)}">`
+    );
+    $root.data('taginputReady', true);
+    sync($root);
+  }
+
+  // Remove a chip via its ×.
+  $(document).on('click', '.fog-tag-x', function() {
+    let $root = $(this).closest('[data-taginput]');
+    $(this).closest('.fog-tag').remove();
+    sync($root);
+  });
+  // Enter or comma commits the entry; Backspace on an empty entry pops the last chip.
+  $(document).on('keydown', '.fog-taginput-entry', function(e) {
+    let $entry = $(this), $root = $entry.closest('[data-taginput]');
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addTag($root, $entry.val());
+      $entry.val('');
+    } else if (e.key === 'Backspace' && !$entry.val()) {
+      $root.find('.fog-tag').last().remove();
+      sync($root);
+    }
+  });
+  // Commit a half-typed tag when focus leaves the widget.
+  $(document).on('blur', '.fog-taginput-entry', function() {
+    addTag($(this).closest('[data-taginput]'), $(this).val());
+    $(this).val('');
+  });
+  // Clicking the empty area of the widget focuses the entry.
+  $(document).on('click', '.fog-taginput', function(e) {
+    if (e.target === this) { $(this).find('.fog-taginput-entry').trigger('focus'); }
+  });
+
+  // Build every widget under `root` (default: the whole document on load).
+  function init(root) {
+    $(root || document).find('[data-taginput]').each(function() { build($(this)); });
+  }
+  $(function() { init(document); });
+
+  window.fogTagInput = {
+    init: init,
+    build: function(el) { build($(el)); },
+    values: function(el) { return values($(el)); }
+  };
+})(jQuery);

--- a/assets/styles/zz-fog-tags.css
+++ b/assets/styles/zz-fog-tags.css
@@ -1,0 +1,54 @@
+/* Tag pills (host list / search) and the chip input widget (host forms + bulk
+ * "Manage tags" modal). Loaded last (zz- prefix) so it overrides Bootstrap. */
+
+/* Read-only pill group, e.g. the host-list Tags column. */
+.fog-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .25rem;
+}
+.fog-tag-list .badge {
+  font-weight: 500;
+}
+
+/* Editable chip input: behaves like a multi-value form-control. */
+.fog-taginput {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: .25rem;
+  height: auto;
+  min-height: calc(1.5em + .75rem + 2px);
+  padding: .25rem .5rem;
+  cursor: text;
+}
+.fog-taginput .fog-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: .3rem;
+  font-weight: 500;
+}
+.fog-tag .fog-tag-x {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  line-height: 1;
+  font-size: 1.05em;
+  opacity: .75;
+  cursor: pointer;
+}
+.fog-tag .fog-tag-x:hover {
+  opacity: 1;
+}
+.fog-taginput-entry {
+  flex: 1 1 6rem;
+  min-width: 6rem;
+  border: 0;
+  padding: .1rem;
+  background: transparent;
+  color: inherit;
+}
+.fog-taginput-entry:focus {
+  outline: 0;
+}

--- a/config/policies.js
+++ b/config/policies.js
@@ -23,8 +23,12 @@ module.exports.policies = {
   'general/save':          ['isLoggedIn','isAuthenticated'],
 
 
-  // Host bulk actions (checks host update permission itself)
-  'host/bulk':             ['isLoggedIn','isAuthenticated'],
+  // Host bulk actions (checks host update permission itself). apiCsrfGuard: a
+  // cookie-authed mutation on /api/v1 (CSRF-exempt at the Sails level), so it
+  // needs the same same-origin guard as general/create|update|destroy.
+  'host/bulk':             ['isLoggedIn','isAuthenticated','apiCsrfGuard'],
+  // Host tag list (checks host read permission itself -- no :model param here)
+  'host/tags':             ['isLoggedIn','isAuthenticated'],
 
   // Image Policies
   'image/capture':         ['isLoggedIn','isAuthenticated', 'image/capture'],

--- a/config/routes.js
+++ b/config/routes.js
@@ -56,8 +56,12 @@ module.exports.routes = {
   // User API
   'GET /api/v1/user/me':                     {action: 'user/listme', csrf: false},
 
-  // Host API
+  // Host API (explicit host routes must precede the generic :model routes below,
+  // or e.g. GET /api/v1/host/tags is read as :model=host/:id=tags). Exempt from
+  // Sails CSRF like the rest of /api/v1; the host/bulk mutation is guarded by
+  // apiCsrfGuard instead (see config/policies.js).
   'POST /api/v1/host/bulk':                  {action: 'host/bulk', csrf: false},
+  'GET /api/v1/host/tags':                   {action: 'host/tags', csrf: false},
 
   // Global search (must precede the :model routes).
   'GET /api/v1/search':                      {action: 'search', csrf: false},

--- a/views/layouts/layout.ejs
+++ b/views/layouts/layout.ejs
@@ -59,6 +59,7 @@
     <link rel="stylesheet" href="/styles/pace-js/themes/blue/pace-theme-minimal.css">
     <link rel="stylesheet" href="/styles/select2/dist/css/select2.min.css">
     <link rel="stylesheet" href="/styles/zz-fog-select2.css">
+    <link rel="stylesheet" href="/styles/zz-fog-tags.css">
     <!--STYLES END-->
   </head>
 
@@ -214,6 +215,7 @@
     <script src="/fog/fog.maclist.js"></script>
     <script src="/fog/fog.search.js"></script>
     <script src="/fog/fog.select2.js"></script>
+    <script src="/fog/fog.taginput.js"></script>
     <!--SCRIPTS END-->
     <% if (partialname) { %>
     <script type="text/javascript">

--- a/views/pages/dashboard.ejs
+++ b/views/pages/dashboard.ejs
@@ -9,6 +9,28 @@
 </div>
 <div class="app-content">
   <div class="container-fluid">
+    <% // Alerts %>
+    <div class="row">
+      <div class="col-12">
+        <div class="card card-outline card-<%= pendingHosts ? 'warning' : 'success' %>">
+          <div class="card-header">
+            <h3 class="card-title">Alerts</h3>
+            <%- partial('../layouts/partials/cardtools.ejs') %>
+          </div>
+          <div class="card-body">
+            <% if (pendingHosts) { %>
+            <a href="/hosts" class="d-inline-flex align-items-center text-decoration-none">
+              <span class="badge bg-warning text-dark me-2"><%= pendingHosts %></span>
+              <%= pendingHosts === 1 ? 'host is' : 'hosts are' %> pending approval
+            </a>
+            <% } else { %>
+            <span class="text-success"><i class="fa fa-check-circle"></i> No pending hosts.</span>
+            <% } %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <% // End Alerts %>
     <% // Overview boxes %>
     <div class="row">
       <div class="col-12">

--- a/views/pages/partials/list/host.js
+++ b/views/pages/partials/list/host.js
@@ -1,33 +1,120 @@
 (function($) {
   let path = $(location).attr('pathname').replace(/s$/,'');
-  function selectedIds(dt) {
-    return dt.rows({selected: true}).data().toArray().map((r) => r.id).filter(Boolean);
-  }
+
   function bulk(dt, body) {
     $.ajax({
       url: '/api/v1/host/bulk',
       type: 'POST',
       contentType: 'application/json',
       data: JSON.stringify(body),
-      complete: function() { dt.ajax.reload(); }
+      complete: function() { dt.ajax.reload(null, false); }
     });
   }
-  // Apply a bulk change to the selected rows, or -- when nothing is selected --
-  // to every host matching the current search (confirmed by count). With
-  // infinite scroll, selection only covers loaded rows, so "all matching" is how
-  // you act on the whole filtered set. `desc` is shown in the confirm prompt.
-  function applyBulk(dt, body, desc) {
-    let ids = selectedIds(dt);
+
+  // Resolve what a bulk action applies to: the selected rows, or -- when nothing
+  // is selected -- every host matching the current search. With infinite scroll,
+  // selection only covers loaded rows, so "all matching" is how you act on the
+  // whole filtered set. The modal itself is the confirmation, so `desc` (shown in
+  // the modal title) makes the scope explicit.
+  function resolveTarget(dt) {
+    let ids = dt.rows({selected: true}).data().toArray().map((r) => r.id).filter(Boolean);
     if (ids.length) {
-      bulk(dt, $.extend({id: ids}, body));
-      return;
+      return { body: {id: ids}, all: false, desc: `${ids.length} selected host(s)` };
     }
     let n = dt.page.info().recordsDisplay,
-      search = dt.search() || '',
-      scope = search ? `all ${n} host(s) matching "${search}"` : `ALL ${n} host(s)`;
-    if (!window.confirm(`No rows selected — ${desc} for ${scope}?`)) { return; }
-    bulk(dt, $.extend({all: true, search: search}, body));
+      search = dt.search() || '';
+    return {
+      body: {all: true, search: search},
+      all: true,
+      desc: search ? `all ${n} host(s) matching "${search}"` : `ALL ${n} host(s)`
+    };
   }
+
+  function escHtml(s) {
+    return $('<span>').text(s == null ? '' : s).html();
+  }
+
+  // Bulk "Manage tags": add (chip input) and remove (checklist) in one request.
+  function openTagModal(dt) {
+    let target = resolveTarget(dt);
+
+    function show(knownTags) {
+      let removeHtml = knownTags.length
+        ? '<div class="fog-tag-remove-list">' + knownTags.map(function(t) {
+          let v = escHtml(t);
+          return '<div class="form-check form-check-inline">' +
+            '<input class="form-check-input" type="checkbox" value="' + v + '">' +
+            '<label class="form-check-label">' + v + '</label></div>';
+        }).join('') + '</div>'
+        : '<p class="text-muted mb-0">No existing tags to remove.</p>';
+
+      let body = document.createElement('div');
+      body.innerHTML =
+        '<div class="mb-3"><label class="form-label fw-semibold">Add tags</label>' +
+          '<div data-taginput data-name="addTags" data-tags=""></div></div>' +
+        '<div><label class="form-label fw-semibold">Remove tags</label>' + removeHtml + '</div>';
+
+      window.fogModal({
+        title: 'Manage Tags — ' + target.desc,
+        body: body,
+        confirmText: 'Apply',
+        onShown: function(wrap) { if (window.fogTagInput) { window.fogTagInput.init(wrap); } },
+        onConfirm: function(wrap) {
+          let addTags = window.fogTagInput
+              ? window.fogTagInput.values(wrap.querySelector('[data-taginput]')) : [],
+            removeTags = $(wrap).find('.fog-tag-remove-list input:checked')
+              .map(function() { return this.value; }).get();
+          if (!addTags.length && !removeTags.length) {
+            window.fogToast('error', 'Add or select at least one tag.');
+            return false;
+          }
+          bulk(dt, $.extend({}, target.body, {addTags: addTags, removeTags: removeTags}));
+        }
+      });
+    }
+
+    // Removable-tag source: the union across selected rows, or -- acting on all
+    // matching -- every tag in the system.
+    if (!target.all) {
+      let seen = {}, list = [];
+      dt.rows({selected: true}).data().toArray().forEach(function(r) {
+        (Array.isArray(r.tags) ? r.tags : []).forEach(function(t) {
+          let k = String(t).toLowerCase();
+          if (!seen[k]) { seen[k] = true; list.push(t); }
+        });
+      });
+      list.sort(function(a, b) { return a.toLowerCase().localeCompare(b.toLowerCase()); });
+      show(list);
+    } else {
+      $.getJSON('/api/v1/host/tags')
+        .done(function(res) { show((res && res.tags) || []); })
+        .fail(function() { show([]); });
+    }
+  }
+
+  // Bulk "Set image": pick from a dropdown (or clear) instead of typing a name.
+  function openImageModal(dt) {
+    let target = resolveTarget(dt);
+    $.getJSON('/api/v1/image').done(function(images) {
+      let opts = '<option value="">(clear image)</option>' +
+        (images || []).map(function(im) {
+          let v = escHtml(im.name);
+          return '<option value="' + v + '">' + v + '</option>';
+        }).join('');
+      let body = '<label class="form-label">Image</label>' +
+        '<select class="form-select" id="fog-bulk-image">' + opts + '</select>';
+      window.fogModal({
+        title: 'Set Image — ' + target.desc,
+        body: body,
+        confirmText: 'Apply',
+        onConfirm: function(wrap) {
+          let name = wrap.querySelector('#fog-bulk-image').value;
+          bulk(dt, $.extend({}, target.body, {image: name}));
+        }
+      });
+    }).fail(function() { window.fogToast('error', 'Could not load images.'); });
+  }
+
   $('#listtable').registerTable(undefined, {
     createMode: 'page',
     order: [
@@ -36,28 +123,12 @@
     // Bulk "push to a set of hosts" actions (the 1.x group replacement).
     extraButtons: [
       {
-        text: '<i class="fa fa-tag"></i> Add Tag',
-        action: function(e, dt) {
-          let tag = window.prompt('Tag to ADD:');
-          if (!tag) { return; }
-          applyBulk(dt, {addTags: [tag]}, `add tag "${tag}"`);
-        }
-      },
-      {
-        text: '<i class="fa fa-tag"></i> Remove Tag',
-        action: function(e, dt) {
-          let tag = window.prompt('Tag to REMOVE:');
-          if (!tag) { return; }
-          applyBulk(dt, {removeTags: [tag]}, `remove tag "${tag}"`);
-        }
+        text: '<i class="fa fa-tags"></i> Manage Tags',
+        action: function(e, dt) { openTagModal(dt); }
       },
       {
         text: '<i class="fa fa-desktop"></i> Set Image',
-        action: function(e, dt) {
-          let name = window.prompt('Image NAME to assign (blank to clear):');
-          if (name === null) { return; }
-          applyBulk(dt, {image: name}, name ? `set image "${name}"` : 'clear image');
-        }
+        action: function(e, dt) { openImageModal(dt); }
       }
     ],
     columns: [
@@ -87,7 +158,11 @@
         data: 'tags',
         orderable: false,
         render: function(data) {
-          return Array.isArray(data) ? data.join(', ') : (data || '');
+          let tags = Array.isArray(data) ? data : (data ? [data] : []);
+          if (!tags.length) { return ''; }
+          return '<span class="fog-tag-list">' + tags.map(function(t) {
+            return '<span class="badge bg-primary">' + escHtml(t) + '</span>';
+          }).join('') + '</span>';
         }
       },
       {data: 'description'}

--- a/views/pages/partials/list/image.js
+++ b/views/pages/partials/list/image.js
@@ -18,7 +18,11 @@
             complete: function(xhr) {
               let r = (xhr && xhr.responseJSON) || {},
                 n = (r.created || []).length;
-              window.alert(r.error ? r.error : (n ? `Discovered ${n} new image(s).` : 'No new images found.'));
+              if (r.error) {
+                window.fogToast('error', r.error);
+              } else {
+                window.fogToast(n ? 'success' : 'info', n ? `Discovered ${n} new image(s).` : 'No new images found.');
+              }
               dt.ajax.reload();
             }
           });


### PR DESCRIPTION
## What & why

A UI-parity pass over the host area so fog-node's flow/operation matches FOG 1.6 (working-1.6) within AdminLTE. Headline: **tags now look and behave like tags**, and the host lists stop using native browser dialogs.

### Tags as tags
- **List** — the Tags column renders as pills instead of `lab-a, win11` text.
- **Host edit + create** — Tags is a chip/token input (type → Enter/comma adds a removable pill; Backspace pops the last). New shared widget `assets/fog/fog.taginput.js` mirrors the existing `fog.maclist.js`; form-generator gains a `taginput` field type. Submits the same comma value the model already normalizes — no save-path change.
- **Bulk "Manage Tags" modal** replaces the two `window.prompt`s: one modal **adds** (chip input) and **removes** (checklist of existing tags) in a single `host/bulk` request. New `GET /api/v1/host/tags` supplies the remove list when acting on all hosts matching the search (selection uses the union of selected rows' tags).

### De-nativized list dialogs
- Set Image prompt → image-dropdown modal.
- Delete `confirm()` → Bootstrap modal; selection `alert()`s → toasts (new `fogModal` / `fogConfirm` / `fogToast` in `fog.common.js`, each degrading to the native dialog if Bootstrap/PNotify is missing). Image "Scan store" result `alert()` → toast.

### Dashboard
- Added the 1.6-style **Alerts** card (hosts pending approval, with count + link).

Out of scope (by design): new 1.6 feature-tabs (printers/snapins/power) — that's plugin/ADR territory, not UI flow.

## Verification
- All touched JS passes `node --check`; throwaway lifted cleanly; grunt linked the two new assets into `layout.ejs` (the only `layout.ejs` change).
- `GET /api/v1/host/tags` returns 403 (not 404) unauthenticated — route present, not shadowed.
- **End-to-end against an isolated seeded DB**: logged in, the Manage-Tags Apply call (`addTags`+`removeTags` together) changed a host's tags as expected; screenshots of the real host list (pills), host edit (chip input), and dashboard (Alerts) confirm rendering.

## Notes / follow-ups
- Dashboard Alerts covers pending **hosts** only (fog-node has no separate pending-MAC concept); the link goes to `/hosts` since there's no pending filter yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
