### PR TITLE
feat(setup): dev sample-data seed + Redis-aware install docs/scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,33 @@ rewrite of the FOG Project server, backed by MongoDB.
 ## Requirements
 
 - **Node.js** — tested on Node 22 (LTS) and Node 26.
-- **MongoDB** — 7.x recommended.
+- **MongoDB** — 7.x recommended (primary datastore).
+- **Redis** — 7.x (session store). **Required**: CSRF protection stores its
+  secret in the session, so login and every form submit fail without it.
 
 ## Development quickstart
 
-A fresh clone can be brought up in four steps:
+A fresh clone comes up in a few steps. The bundled compose file starts both
+MongoDB and Redis:
 
 ```sh
 # 1. Install dependencies
 npm install
 
-# 2. Start a development MongoDB (no auth — dev only)
+# 2. Start MongoDB + Redis (no auth — dev only)
 docker compose up -d        # or: podman compose up -d
-# No compose plugin? Run Mongo directly:
+# No compose plugin? Run them directly:
 #   podman run -d --name fog-node-mongo -p 127.0.0.1:27017:27017 docker.io/library/mongo:7
+#   podman run -d --name fog-node-redis -p 127.0.0.1:6379:6379 docker.io/library/redis:7-alpine
 
-# 3. Write dev config + seed the Administrator account (non-interactive)
+# 3. Write dev config (config/local.js + config/models.js) + seed the Administrator
 npm run setup:dev
 
-# 4. Start the server
+# 4. (Optional) load sample data to click around -- a storage group + node,
+#    a couple of images, and a handful of hosts. Resets the dev database.
+npm run seed:dev
+
+# 5. Start the server
 npm start                   # or: node app.js
 ```
 
@@ -35,21 +43,33 @@ Then browse to <http://localhost:1337> and log in as `Administrator`
 (default password `fogadmin1` — change it, or override at setup time).
 
 `setup:dev` writes the git-ignored `config/local.js` and `config/models.js`
-with localhost defaults. Override any of them via env vars (see the header of
+with localhost defaults (Mongo on `:27017`, Redis via `config/session.js` on
+`:6379`, `migrate: 'safe'`). Override any of them via env vars (see the header of
 [tools/setup/dev.js](tools/setup/dev.js)), e.g.:
 
 ```sh
 FOG_DEV_ADMIN_PASSWORD='supersecret' FOG_DEV_DB_NAME='fogdev' npm run setup:dev
 ```
 
+> **Heads-up:** the schema uses `migrate: 'safe'` (never auto-migrate — Mongo is
+> schemaless, so none is needed). Don't point two app instances at one database
+> with `migrate: 'alter'`; that can wipe it.
+
 ## Production install
 
-For a real install, run the interactive installer instead of `setup:dev`:
+For a real install, run the interactive installer:
 
 ```sh
-node tools/setup/index.js   # prompts for DB, admin account, webserver, etc.
-npm start                   # NODE_ENV=production node app.js
+npm run setup              # prompts for DB, admin account, webserver, etc.
+npm start                  # NODE_ENV=production node app.js
 ```
+
+You still need **MongoDB and Redis** reachable. The installer writes the DB
+connection; sessions default to `redis://127.0.0.1:6379/0` in
+[config/session.js](config/session.js) — point that at your Redis. For a durable
+systemd + Podman (Quadlet) deployment behind nginx — covering the Mongo and Redis
+containers, the service units, and the reverse proxy — see the **Persistent
+deployment** section below.
 
 ## Persistent deployment (systemd autostart + nginx reverse proxy)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,12 @@
-# Development MongoDB for fog-node.
+# Development MongoDB + Redis for fog-node.
 #
-# This is for LOCAL DEVELOPMENT ONLY -- it runs Mongo with no authentication,
-# matching the default connection string written by `npm run setup:dev`
-# (mongodb://127.0.0.1:27017/fog). Do not use this for production.
+# This is for LOCAL DEVELOPMENT ONLY -- it runs Mongo with no authentication and
+# Redis with no password, matching the defaults written by `npm run setup:dev`
+# (mongodb://127.0.0.1:27017/fog and redis://127.0.0.1:6379/0). Do not use this
+# for production.
+#
+# Redis backs the session store, which is REQUIRED: the CSRF token's secret lives
+# in the session, so login and every form submit fail without it.
 #
 # Works with either Docker or Podman:
 #   docker compose up -d        (or)   podman compose up -d
@@ -18,5 +22,16 @@ services:
     volumes:
       - fog-node-mongo-data:/data/db
 
+  redis:
+    image: redis:7-alpine
+    container_name: fog-node-redis
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - fog-node-redis-data:/data
+
 volumes:
   fog-node-mongo-data:
+  fog-node-redis-data:

--- a/package.json
+++ b/package.json
@@ -88,7 +88,9 @@
   },
   "scripts": {
     "start": "NODE_ENV=production node app.js",
+    "setup": "node tools/setup/index.js",
     "setup:dev": "node tools/setup/dev.js",
+    "seed:dev": "node tools/setup/seed-dev.js",
     "test": "npm run lint && npm run custom-tests && echo 'Done.'",
     "lint": "./node_modules/eslint/bin/eslint.js . --max-warnings=0 --report-unused-disable-directives && echo '✔  Your .js files look good.'",
     "custom-tests": "echo \"(No other custom tests yet.)\" && echo"

--- a/tools/setup/lib/schema.js
+++ b/tools/setup/lib/schema.js
@@ -24,7 +24,10 @@ module.exports = {
     if (!cfg.schema) cfg.schema = 1;
     cfg.appPath = config.appPath;
     cfg.models = {};
-    cfg.models.migrate = 'alter';
+    // 'safe' = never auto-migrate. Mongo is schemaless so no migration is needed,
+    // and 'alter' can drop/recreate collections (data loss) -- catastrophically so
+    // if another app instance is pointed at the same database while this runs.
+    cfg.models.migrate = 'safe';
     adminUser.email = adminEmail;
     adminUser.password = adminPassword;
     sails.load(cfg, async (err) => {

--- a/tools/setup/seed-dev.js
+++ b/tools/setup/seed-dev.js
@@ -1,0 +1,95 @@
+/**
+ * Dev sample-data seed for fog-node.
+ *
+ * Resets the development database to a clean, playable baseline so a fresh
+ * instance has something to click around on first load:
+ *   - Administrator user + Administrator role + schema setting
+ *   - a Default storage group with one storage node
+ *   - a couple of images and a handful of sample hosts (with MACs, tags, and an
+ *     image assignment) and a PXE menu
+ *
+ * SAFE on the schema (lifts Sails with migrate:'safe' — never auto-migrates),
+ * but DESTRUCTIVE on data: it clears the seeded collections first. LOCAL
+ * DEVELOPMENT ONLY — it refuses to run with NODE_ENV=production.
+ *
+ *   npm run seed:dev
+ *   FOG_DEV_ADMIN_PASSWORD='supersecret' npm run seed:dev
+ */
+const config = require('../lib/config'),
+  sails = require('sails');
+
+if (process.env.NODE_ENV === 'production') {
+  console.error('Refusing to run the dev seed with NODE_ENV=production (it clears data).');
+  process.exit(1);
+}
+
+const adminEmail = process.env.FOG_DEV_ADMIN_EMAIL || 'admin@example.com';
+const adminPassword = process.env.FOG_DEV_ADMIN_PASSWORD || 'fogadmin1';
+if (adminPassword.length < 8) {
+  console.error('FOG_DEV_ADMIN_PASSWORD must be at least 8 characters.');
+  process.exit(1);
+}
+
+(function () {
+  let cfg = config.getMergedSettings();
+  cfg.log = { level: 'error' };
+  if (!cfg.schema) cfg.schema = 1;
+  cfg.appPath = config.appPath;
+  cfg.models = { migrate: 'safe' }; // never auto-migrate (Mongo is schemaless)
+  cfg.hooks = { grunt: false };     // no asset build needed just to seed
+
+  sails.load(cfg, async (err) => {
+    if (err) { console.error(err); process.exit(1); }
+    try {
+      // Clean slate for the seeded collections (dev only).
+      await Promise.all([
+        Host.destroy({}), Image.destroy({}), StorageNode.destroy({}),
+        StorageGroup.destroy({}), PxeMenu.destroy({}), User.destroy({}),
+        Role.destroy({}), Setting.destroy({})
+      ]);
+
+      // --- Baseline: schema revision + Administrator role + Administrator user ---
+      await Setting.create({ name: 'schema', value: { revision: cfg.schema } });
+      let adminRole = await Role.create({ name: 'Administrator', isAdmin: true, permissions: {} }).fetch();
+      let admin = await User.create({ username: 'Administrator', email: adminEmail, password: adminPassword }).fetch();
+      await User.addToCollection(admin.id, 'roles').members([adminRole.id]);
+
+      // --- Storage: one group + one (master) node ---
+      let sg = await StorageGroup.create({ name: 'Default', description: 'Default storage group' }).fetch();
+      await StorageNode.create({
+        name: 'DefaultMember', description: 'Default storage node',
+        ip: '127.0.0.1', path: '/images/', ftppath: '/images/', snapinpath: '/opt/fog/snapins/',
+        isMaster: true, isEnabled: true, maxClients: 10, storagegroup: sg.id
+      });
+
+      // --- Images ---
+      let win = await Image.create({ name: 'Golden-Win11', description: 'Sample Windows 11 image', enabled: true }).fetch();
+      await Image.create({ name: 'Ubuntu-22.04', description: 'Sample Ubuntu 22.04 image', enabled: true });
+
+      // --- PXE menu ---
+      await PxeMenu.create({ name: 'Default' });
+
+      // --- Sample hosts ---
+      let hosts = [
+        { name: 'lab-pc-01', description: 'Lab A workstation', macs: ['00:11:22:33:44:01'], tags: ['lab-a', 'win11'], image: win.id },
+        { name: 'lab-pc-02', description: 'Lab A workstation', macs: ['00:11:22:33:44:02'], tags: ['lab-a', 'win11'], image: win.id },
+        { name: 'lab-pc-03', description: 'Lab B workstation', macs: ['00:11:22:33:44:03'], tags: ['lab-b'] },
+        { name: 'reception-01', description: 'Front desk', macs: ['00:11:22:33:44:04'], tags: ['front-desk'] },
+        { name: 'unprovisioned-01', description: 'Newly registered, no image', macs: ['00:11:22:33:44:05'], pending: true }
+      ];
+      for (let h of hosts) { await Host.create(h); }
+
+      console.log('');
+      console.log('Dev sample data seeded:');
+      console.log('  users: 1 (Administrator)   roles: 1   storage groups: 1   storage nodes: 1');
+      console.log('  images: 2   hosts: ' + hosts.length + '   pxe menus: 1');
+      console.log('');
+      console.log('  Login: Administrator / ' + adminPassword);
+      console.log('');
+      process.exit(0);
+    } catch (e) {
+      console.error('Seed failed: ' + (e && e.message ? e.message : e));
+      process.exit(1);
+    }
+  });
+})();


### PR DESCRIPTION
Makes a fresh CLI install **just work** and gives it sample data to play with.

## Why
`config/session.js` now requires Redis (CSRF secret lives in the session), but the dev quickstart, `docker-compose.yml`, and installer never started it — so a fresh clone **failed on first login**. The seed only created the Administrator, so there was nothing to click around on.

## Changes
- **`tools/setup/seed-dev.js`** + `npm run seed:dev`: resets the dev DB to a clean, playable baseline — Administrator + role, a **Default** storage group + node, **2 images**, **5 sample hosts** (with MACs/tags/image assignment), a PXE menu. Lifts with `migrate: 'safe'`; refuses `NODE_ENV=production`.
- **`docker-compose.yml`**: add **Redis** (was Mongo-only) — `docker compose up -d` now starts both.
- **`tools/setup/lib/schema.js`**: the admin seed forced `migrate: 'alter'` (the wipe footgun) → `'safe'`.
- **`package.json`**: add `setup` (interactive installer) and `seed:dev` scripts.
- **README**: rewrite quickstart + production install to include Redis, the session-store requirement, the optional sample seed, and the `migrate: 'safe'` caveat.

## Verified
Ran the seed against the dev DB: 1 admin, 1 role, 5 hosts, 2 images, 1 storage group + node, 1 PXE menu; `:1337` login works.

Follow-up (not in this PR): `tools/setup/index.js` still has some dead code (generates an unused keypair, collects webserver flags it never writes) — worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)