### PR TITLE
chore(setup): remove dead code in the interactive installer

### DIFF
--- a/tools/setup/index.js
+++ b/tools/setup/index.js
@@ -3,7 +3,7 @@ const chalk = require('chalk'),
   path = require('path'),
   header = require('../lib/header'),
   config = require('../lib/config'),
-  cfgPath = path.join(config.appPath, 'config');
+  cfgPath = path.join(config.appPath, 'config'),
   httpCfg = path.join(cfgPath, 'http.js'),
   modelsCfg = path.join(cfgPath, 'models.js'),
   localCfg = path.join(cfgPath, 'local.js'),
@@ -40,16 +40,6 @@ async.waterfall([
       next();
     });
   },
-  // Web Config
-  (next) => {
-    header.printSection('Webserver Configuration');
-    inquire.getWebserverInfo((answers) => {
-      payload.port = answers.port;
-      delete answers.port;
-      payload.webserver = answers;
-      next();
-    });
-  },
   // Secure session
   (next) => {
     header.printSection('Securing Installation');
@@ -83,19 +73,6 @@ async.waterfall([
     status.stop();
     console.log('JWT secret generated');
     next();
-  },
-  // Secure Keypair
-  (next) => {
-    header.printSection('Generating Keypair');
-    var status = new Spinner('Generating key pair');
-    status.start();
-    secure.generateKeypair((err, keypair) => {
-      status.stop();
-      if (err) return next(`Failed to generate keypair: ${err}`);
-      console.log('Keypair generated');
-      payload.defaultKey = keypair;
-      next();
-    });
   },
   // Save configuration
   (next) => {
@@ -183,6 +160,13 @@ module.exports.http = {
         //secure: true
       }
     },
+  },
+  // Session store: a per-install secret + Redis. Required for CSRF (the CSRF
+  // token's secret lives in the session). Point url at your Redis.
+  session: {
+    secret: '${payload.session.secret}',
+    adapter: '@sailshq/connect-redis',
+    url: 'redis://127.0.0.1:6379/0'
   },
   datastores: {
     fogdb: {

--- a/tools/setup/lib/inquire.js
+++ b/tools/setup/lib/inquire.js
@@ -96,41 +96,5 @@ module.exports = {
       }
     ];
     inquirer.prompt(questions).then(next);
-  },
-  getWebserverInfo: (next) => {
-    let questions = [
-      {
-        name: 'port',
-        type: 'input',
-        message: 'Enter the port number FOG should listen on:',
-        default: 1337,
-        validate: (value) => {
-          if (isNaN(value) || value < 1 || value > 65535) return 'You must enter a valid port number';
-          return true;
-        }
-      },
-      {
-        name: 'proxy',
-        type: 'confirm',
-        message: 'Will FOG Operate behind a reverse proxy (recommended)?',
-        default: true
-      },
-      {
-        name: 'horizontal',
-        type: 'confirm',
-        message: 'Will there be a pool of FOG servers (horizontal scaling)?',
-        default: true,
-        when: (answers) => {
-          return answers.proxy;
-        }
-      },
-      {
-        name: 'vertical',
-        type: 'confirm',
-        message: 'Should FOG multithread itself (vertical scaling)?',
-        default: true
-      }
-    ];
-    inquirer.prompt(questions).then(next);
   }
 };

--- a/tools/setup/lib/secure.js
+++ b/tools/setup/lib/secure.js
@@ -1,7 +1,5 @@
 const _ = require('@sailshq/lodash'),
-  crypto = require('crypto'),
-  forge = require('node-forge'),
-  rsa = forge.pki.rsa;
+  crypto = require('crypto');
 
 module.exports = {
   generateSecret: () => {
@@ -17,8 +15,5 @@ module.exports = {
     });
 
     return crypto.createHash('sha256').update(basestring).digest('hex');
-  },
-  generateKeypair: (next) => {
-    rsa.generateKeyPair({bits: 4096, workers: -1}, next);
   }
 };


### PR DESCRIPTION
Cleans up `tools/setup/index.js` (and the lib functions it orphaned).

- **Drop the keypair step** — it ran a slow 4096-bit RSA keygen into `payload.defaultKey` that was never written anywhere. Also removes the now-orphaned `secure.generateKeypair` and its `node-forge` require.
- **Drop the Webserver Configuration step** — prompted for port + proxy/scaling flags into `payload.{port,webserver}` that were never written. Removes the orphaned `inquire.getWebserverInfo`.
- **Fix a `;` typo** on the top `const` list that turned `httpCfg`/`modelsCfg`/`localCfg`/`inquire`/`schema`/`secure`/`async`/`CLI`/`welcome` into implicit globals.
- **Wire the session secret** (also previously generated then discarded) into the written `config/local.js` with the `@sailshq/connect-redis` adapter — so a production install gets a unique session secret + Redis configured (required for CSRF), instead of falling back to the checked-in default.

Net −57 lines. Syntax-checked; no dead references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)