### PR TITLE
Fix 403 on all authenticated mutations (session CSRF secret) + filterable association picker

### DIFF
--- a/api/helpers/form-generator.js
+++ b/api/helpers/form-generator.js
@@ -138,28 +138,49 @@ module.exports = {
           return field;
         }
         case 'checktable': {
+          // Multi (collection) association picker: a filterable, select-all
+          // checkbox table. Behaviour wired by assets/fog/fog.assoc.js; styled
+          // by assets/styles/zz-fog-assoc.css.
+          let opts = input.options || [];
+          let total = opts.length;
+          let selected = opts.filter((o) => o.checked).length;
           field += `
             <div class="row mb-3">
               <label class="col-sm-2 col-form-label">${input.text}</label>
-              <div class="col-sm-10">
-                <div class="border rounded" style="max-height:220px;overflow:auto">
-                  <table class="table table-sm table-hover mb-0">
-                    <tbody>`;
-          if (!(input.options || []).length) {
+              <div class="col-sm-10">`;
+          if (!total) {
             field += `
-                      <tr><td class="text-muted">None available.</td></tr>`;
+                <div class="assoc-empty">None available.</div>`;
+          } else {
+            field += `
+                <div class="assoc-picker" data-assoc-picker>
+                  <div class="assoc-toolbar">
+                    <div class="form-check">
+                      <input class="form-check-input" type="checkbox" id="assoc-all-${item}" data-assoc-all/>
+                      <label class="form-check-label" for="assoc-all-${item}">Select all</label>
+                    </div>
+                    <span class="assoc-count text-muted" data-assoc-count><strong>${selected}</strong> of ${total} selected</span>
+                    <div class="assoc-search">
+                      <input type="search" class="form-control form-control-sm" data-assoc-search placeholder="Filter&hellip;" aria-label="Filter ${input.text}"/>
+                    </div>
+                  </div>
+                  <div class="assoc-scroll">
+                    <table class="table table-sm table-striped table-hover align-middle mb-0">
+                      <tbody>`;
+            opts.forEach((o) => {
+              field += `
+                        <tr class="assoc-row${o.checked ? ' selected' : ''}">
+                          <td class="assoc-check"><input type="checkbox" class="form-check-input" name="${item}[]" value="${o.value}"${o.checked ? ' checked' : ''}/></td>
+                          <td class="assoc-name">${o.label}</td>
+                        </tr>`;
+            });
+            field += `
+                      </tbody>
+                    </table>
+                  </div>
+                </div>`;
           }
-          (input.options || []).forEach((o) => {
-            field += `
-                      <tr>
-                        <td style="width:2.5rem"><input type="checkbox" class="form-check-input" name="${item}[]" value="${o.value}"${o.checked ? ' checked' : ''}/></td>
-                        <td>${o.label}</td>
-                      </tr>`;
-          });
           field += `
-                    </tbody>
-                  </table>
-                </div>
               </div>
             </div>`;
           return field;

--- a/api/policies/isLoggedIn.js
+++ b/api/policies/isLoggedIn.js
@@ -26,7 +26,13 @@ module.exports = async (req, res, next) => {
       if (!user) return next();
       req.authVia = 'session';
       user = user.toJSON();
-      await req.login(user, async (err) => err ? next(err) : next());
+      // keepSessionInfo: Passport >=0.6 regenerates the session on req.login
+      // (fixation protection). Since this policy re-logs-in on every
+      // authenticated request, a plain login would wipe the session each time --
+      // including the CSRF secret -- so the token rendered on a GET never
+      // validates on the following POST (403). Preserve existing session data
+      // across the regenerate. (The apitoken path above is stateless: session:false.)
+      await req.login(user, { keepSessionInfo: true }, async (err) => err ? next(err) : next());
     })(req, res);
   } catch (e) {
     next();

--- a/assets/fog/fog.assoc.js
+++ b/assets/fog/fog.assoc.js
@@ -1,0 +1,96 @@
+/**
+ * fog.assoc.js
+ *
+ * Behaviour for the multi-association picker (the "checktable" form item built
+ * by api/helpers/form-generator.js): select-all, a live "N of M selected"
+ * count, a per-picker text filter, and the selected-row highlight class.
+ *
+ * Uses event delegation on document, so it covers both the full-page edit form
+ * and the lazy-loaded create/edit modal (which injects its form after open).
+ * Markup contract:
+ *   [data-assoc-picker]      wrapper
+ *     [data-assoc-all]       the select-all checkbox
+ *     [data-assoc-count]     count display
+ *     [data-assoc-search]    the filter input
+ *     tr.assoc-row           one per option; .selected = chosen
+ *       td.assoc-check input the row checkbox
+ *       td.assoc-name        the label text the filter matches
+ */
+(function () {
+  function rows(picker) {
+    return Array.prototype.slice.call(picker.querySelectorAll('.assoc-row'));
+  }
+  function visibleRows(picker) {
+    return rows(picker).filter(function (r) { return !r.classList.contains('assoc-hidden'); });
+  }
+  function rowBox(r) {
+    return r.querySelector('td.assoc-check input[type="checkbox"]');
+  }
+
+  // Recompute row highlight, the count, and the select-all (checked /
+  // indeterminate) state for a single picker.
+  function refresh(picker) {
+    var all = rows(picker), selected = 0;
+    all.forEach(function (r) {
+      var cb = rowBox(r), on = !!(cb && cb.checked);
+      r.classList.toggle('selected', on);
+      if (on) { selected++; }
+    });
+
+    var count = picker.querySelector('[data-assoc-count]');
+    if (count) {
+      count.innerHTML = '<strong>' + selected + '</strong> of ' + all.length + ' selected';
+    }
+
+    var master = picker.querySelector('[data-assoc-all]');
+    if (master) {
+      // Base the master state on the rows the user can currently see.
+      var vis = visibleRows(picker);
+      var visOn = vis.filter(function (r) { var c = rowBox(r); return c && c.checked; }).length;
+      master.checked = vis.length > 0 && visOn === vis.length;
+      master.indeterminate = visOn > 0 && visOn < vis.length;
+    }
+  }
+
+  function refreshAll(ctx) {
+    var root = (ctx && ctx.querySelectorAll) ? ctx : document;
+    Array.prototype.forEach.call(root.querySelectorAll('[data-assoc-picker]'), refresh);
+  }
+
+  // Checkbox changes: select-all toggles the visible rows; any change refreshes.
+  document.addEventListener('change', function (e) {
+    var t = e.target;
+    if (!t || t.type !== 'checkbox') { return; }
+    var picker = t.closest && t.closest('[data-assoc-picker]');
+    if (!picker) { return; }
+    if (t.hasAttribute('data-assoc-all')) {
+      var on = t.checked;
+      visibleRows(picker).forEach(function (r) { var c = rowBox(r); if (c) { c.checked = on; } });
+    }
+    refresh(picker);
+  });
+
+  // Filter: hide non-matching rows by their label text.
+  document.addEventListener('input', function (e) {
+    var t = e.target;
+    if (!t || !t.hasAttribute || !t.hasAttribute('data-assoc-search')) { return; }
+    var picker = t.closest && t.closest('[data-assoc-picker]');
+    if (!picker) { return; }
+    var q = t.value.trim().toLowerCase();
+    rows(picker).forEach(function (r) {
+      var name = (r.querySelector('.assoc-name') || {}).textContent || '';
+      r.classList.toggle('assoc-hidden', !!q && name.toLowerCase().indexOf(q) === -1);
+    });
+    refresh(picker);
+  });
+
+  function ready() { refreshAll(document); }
+  if (document.readyState !== 'loading') { ready(); }
+  else { document.addEventListener('DOMContentLoaded', ready); }
+
+  // The create/edit modal injects a server-rendered form once shown.
+  document.addEventListener('shown.bs.modal', function (e) { refreshAll(e.target); });
+
+  // Let code that injects its own pickers re-sync them.
+  window.fogInitAssoc = refreshAll;
+})();

--- a/assets/fog/fog.csrf.js
+++ b/assets/fog/fog.csrf.js
@@ -7,9 +7,10 @@
  *   - window.fetch (the create/edit modal, credential + account panels)
  *   - full-page form submits (login, edit) via an injected hidden _csrf field
  *
- * The token comes from `SAILS_LOCALS._csrf` (exposed by exposeLocalsToBrowser)
- * when present, otherwise from `GET /csrfToken`. `/api/v1/*` is exempt server
- * side, so token-authenticated API clients are unaffected.
+ * The token comes (in order) from the `<meta name="csrf-token">` rendered into
+ * every page's <head> (synchronous, so it's set before any on-load AJAX),
+ * then `SAILS_LOCALS._csrf`, then an async `GET /csrfToken`. `/api/v1/*` is
+ * exempt server side, so token-authenticated API clients are unaffected.
  */
 (function () {
   var token = null;
@@ -55,7 +56,16 @@
     }
   }
 
-  var local = (window.SAILS_LOCALS && window.SAILS_LOCALS._csrf) || null;
+  // Prefer the synchronous token: a <meta name="csrf-token"> rendered into every
+  // page's <head>, so $.ajaxSetup + the fetch wrapper are wired before the page
+  // fires any AJAX. Fall back to SAILS_LOCALS, then to an async GET /csrfToken.
+  function metaToken() {
+    var m = document.querySelector('meta[name="csrf-token"]');
+    var v = m && m.getAttribute('content');
+    return v ? v : null;
+  }
+
+  var local = metaToken() || (window.SAILS_LOCALS && window.SAILS_LOCALS._csrf) || null;
   if (local) {
     apply(local);
   } else if (window.fetch) {

--- a/assets/styles/zz-fog-assoc.css
+++ b/assets/styles/zz-fog-assoc.css
@@ -1,0 +1,72 @@
+/*
+ * zz-fog-assoc.css
+ *
+ * Multi-association picker (the "checktable" form item built by
+ * api/helpers/form-generator.js): a filterable, select-all checkbox table used
+ * on create/edit forms for collection associations (snapins, printers, etc.).
+ *
+ * Like zz-fog-select2.css, this uses Bootstrap 5 CSS variables (with light-mode
+ * fallbacks) so it follows AdminLTE's light/dark theme, and the `zz-` prefix
+ * keeps it loading after the framework styles in the alphabetical asset inject.
+ */
+
+.assoc-picker {
+  border: 1px solid var(--bs-border-color, #dee2e6);
+  border-radius: 0.375rem;
+  overflow: hidden;
+  background: var(--bs-body-bg, #fff);
+}
+
+/* Toolbar: select-all + live count on the left, filter on the right. */
+.assoc-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  background: var(--bs-tertiary-bg, #f8f9fa);
+  border-bottom: 1px solid var(--bs-border-color, #dee2e6);
+}
+.assoc-toolbar .form-check {
+  margin: 0;
+  min-height: auto;
+}
+.assoc-count {
+  font-size: 0.8125rem;
+  white-space: nowrap;
+}
+.assoc-search {
+  width: 11rem;
+  margin-left: auto;
+}
+
+/* Scroll body. */
+.assoc-scroll {
+  max-height: 240px;
+  overflow: auto;
+}
+.assoc-check {
+  width: 2.75rem;
+  text-align: center;
+}
+
+/* Selected-row cue: subtle tint + primary accent bar (mirrors the "active row"
+   highlight of the FOG 1.x association tables). */
+.assoc-row.selected > td {
+  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.06);
+}
+.assoc-row.selected > td:first-child {
+  box-shadow: inset 0.2rem 0 0 var(--bs-primary, #0d6efd);
+}
+
+/* Rows hidden by the filter. */
+.assoc-row.assoc-hidden {
+  display: none;
+}
+
+/* Empty state (no candidates to associate). */
+.assoc-empty {
+  padding: 0.6rem 0.75rem;
+  color: var(--bs-secondary-color, #6c757d);
+  border: 1px solid var(--bs-border-color, #dee2e6);
+  border-radius: 0.375rem;
+}

--- a/views/layouts/layout.ejs
+++ b/views/layouts/layout.ejs
@@ -63,6 +63,7 @@
     <link rel="stylesheet" href="/styles/importer.css">
     <link rel="stylesheet" href="/styles/pace-js/themes/blue/pace-theme-minimal.css">
     <link rel="stylesheet" href="/styles/select2/dist/css/select2.min.css">
+    <link rel="stylesheet" href="/styles/zz-fog-assoc.css">
     <link rel="stylesheet" href="/styles/zz-fog-select2.css">
     <link rel="stylesheet" href="/styles/zz-fog-tags.css">
     <!--STYLES END-->
@@ -217,6 +218,7 @@
     <script src="/js/pdfmake/build/pdfmake.min.js"></script>
     <script src="/js/select2/dist/js/select2.full.min.js"></script>
     <script src="/fog/fog.common.js"></script>
+    <script src="/fog/fog.assoc.js"></script>
     <script src="/fog/fog.csrf.js"></script>
     <script src="/fog/fog.maclist.js"></script>
     <script src="/fog/fog.search.js"></script>

--- a/views/layouts/layout.ejs
+++ b/views/layouts/layout.ejs
@@ -12,6 +12,11 @@
     <!-- Viewport mobile tag for sensible mobile support -->
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
+    <%/* CSRF token, available synchronously to fog.csrf.js (which wires the token
+         into jQuery AJAX + fetch) before any on-load request fires. Rendered on
+         every page from the per-request session token. */%>
+    <meta name="csrf-token" content="<%= (typeof _csrf !== 'undefined' && _csrf) ? _csrf : '' %>">
+
     <%/* If you want to discourage search engines from indexing this site, uncomment the following line: */%>
     <%/* <meta name="robots" content="noindex"> */%>
 
@@ -212,6 +217,7 @@
     <script src="/js/pdfmake/build/pdfmake.min.js"></script>
     <script src="/js/select2/dist/js/select2.full.min.js"></script>
     <script src="/fog/fog.common.js"></script>
+    <script src="/fog/fog.csrf.js"></script>
     <script src="/fog/fog.maclist.js"></script>
     <script src="/fog/fog.search.js"></script>
     <script src="/fog/fog.select2.js"></script>

--- a/views/layouts/layout.ejs
+++ b/views/layouts/layout.ejs
@@ -84,7 +84,7 @@
       <footer class="app-footer">
         <div class="float-end d-none d-sm-inline">
           <b>Channel</b> Alpha |&nbsp;
-          <b>Version</b> <a href="/"><%= version %></a>
+          <b>Version</b> <a href="/"><%= typeof version !== 'undefined' ? version : '' %></a>
         </div>
         <strong>Copyright &copy; 2007-2026&nbsp;
           <a href="https://fogproject.org">FOG Project</a>.</strong>&nbsp;
@@ -225,7 +225,7 @@
     <script src="/fog/fog.select2.js"></script>
     <script src="/fog/fog.taginput.js"></script>
     <!--SCRIPTS END-->
-    <% if (partialname) { %>
+    <% if (typeof partialname !== 'undefined' && partialname) { %>
     <script type="text/javascript">
     <%- partial(partialname) %>
     </script>


### PR DESCRIPTION
## 1. fix(csrf): every authenticated mutation was 403ing

Passport >=0.6 regenerates the session on `req.login()` (fixation protection), and `isLoggedIn` re-logs-in on **every** authenticated request — so the session's `csrfSecret` was wiped each request. The token a page renders (`<%= _csrf %>`) was tied to a secret gone by the next POST → **403 on every save/delete/AJAX mutation** (host/user edit-save, dashboard `task-history`, row deletes, bulk actions, password reset, API-token regen). `/csrfToken` worked only because it's public and skips the policy.

- `api/policies/isLoggedIn.js`: pass `{ keepSessionInfo: true }` to `req.login` on the JWT path so the secret survives the regenerate. (Deliberately **not** `session:false` — the socket branch in `isAuthenticated.js` reads `req.session.passport.user`.)
- `views/layouts/layout.ejs` + `assets/fog/fog.csrf.js`: render `<meta name="csrf-token">` and read it **synchronously**, so `$.ajaxSetup`/`fetch` carry the token before any on-load AJAX (removes the async `/csrfToken` race; `exposeLocalsToBrowser()` omits `_csrf`).

Verified on a running instance: form-token `POST /users/edit` → **200**, AJAX `POST /task-history` → **200** (both were 403 before).

## 2. feat(web): filterable multi-association picker

Reworked the `checktable` form item (create/edit forms) into a **select-all + live "N of M selected" + filter** checkbox table with a selected-row highlight, matching the working-1.6 association UX.

- `api/helpers/form-generator.js`, new `assets/fog/fog.assoc.js`, new `assets/styles/zz-fog-assoc.css`.

## Follow-up (not in this PR)
The session id still rotates every authenticated request (Passport rotates the id even with `keepSessionInfo`) → Redis accumulates orphan `sess:*` keys (they expire by TTL). Cleaner long-term: only `req.login` at actual login, or move sockets off session auth and use `session:false` for JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)