### PR TITLE
chore(lint): align two rules with house style, then autofix the rest

### DIFF
--- a/api/controllers/HostController.js
+++ b/api/controllers/HostController.js
@@ -6,7 +6,7 @@
  */
 
 module.exports = {
-  
+
 
 };
 

--- a/api/controllers/ImageController.js
+++ b/api/controllers/ImageController.js
@@ -6,7 +6,7 @@
  */
 
 module.exports = {
-  
+
 
 };
 

--- a/api/controllers/RoleController.js
+++ b/api/controllers/RoleController.js
@@ -6,7 +6,7 @@
  */
 
 module.exports = {
-  
+
 
 };
 

--- a/api/controllers/WorkflowController.js
+++ b/api/controllers/WorkflowController.js
@@ -6,7 +6,7 @@
  */
 
 module.exports = {
-  
+
 
 };
 

--- a/api/controllers/account/reset-api-token.js
+++ b/api/controllers/account/reset-api-token.js
@@ -10,8 +10,8 @@ module.exports = {
     let req = this.req;
     if (req.authVia === 'apitoken') return exits.forbidden();
     if (!req.user) return exits.forbidden();
-    let token = 'fpat_' + crypto.randomBytes(24).toString('hex'),
-      hash = crypto.createHash('sha256').update(token).digest('hex');
+    let token = 'fpat_' + crypto.randomBytes(24).toString('hex');
+    let hash = crypto.createHash('sha256').update(token).digest('hex');
     await User.updateOne({ id: req.user.id }).set({ apiTokenHash: hash });
     return exits.success({ ok: true, token });
   }

--- a/api/controllers/auth/login.js
+++ b/api/controllers/auth/login.js
@@ -1,5 +1,5 @@
-const passport = require('passport'),
-  jwt = require('jsonwebtoken');
+const passport = require('passport');
+const jwt = require('jsonwebtoken');
 module.exports = {
   friendlyName: 'Login',
   description: 'Login auth.',
@@ -9,9 +9,9 @@ module.exports = {
     }
   },
   fn: async function (inputs, exits) {
-    let req = this.req,
-      res = this.res;
-    await passport.authenticate(sails.config.globals.authenticationMechanisms, async function(err, user, info) {
+    let req = this.req;
+    let res = this.res;
+    await passport.authenticate(sails.config.globals.authenticationMechanisms, async (err, user, info) => {
       if (err) return exits.error(err);
       // No user => bad credentials. Return a clean 401 (JSON) or bounce back to
       // the login form, instead of calling req.login(undefined) which throws a
@@ -24,13 +24,13 @@ module.exports = {
         }
         return res.redirect('/login?failed=1');
       }
-      await req.login(user, async function(err) {
+      await req.login(user, async (err) => {
         if (err) return exits.error(err);
         await jwt.sign(
           {user: user.id},
           sails.config.auth.jwt.secret,
           sails.config.auth.jwt.options,
-          async function(err, token) {
+          async (err, token) => {
             if (err) return exits.error(err);
             if (!token) return exits.error('Invalid token created');
             if (req.param('remember-me') == 'on') res.cookie('jwt', token, sails.config.auth.jwt.cookie);

--- a/api/controllers/auth/logout.js
+++ b/api/controllers/auth/logout.js
@@ -6,8 +6,8 @@ module.exports = {
   exits: {
   },
   fn: async function (inputs) {
-    let req = this.req,
-      res = this.res;
+    let req = this.req;
+    let res = this.res;
     // passport >= 0.6 made req.logout() asynchronous -- it requires a callback
     // and throws (500) if called the old synchronous way. Await it so the action
     // doesn't return (and send a default response) before the redirect.

--- a/api/controllers/auth/token.js
+++ b/api/controllers/auth/token.js
@@ -1,6 +1,6 @@
-const jwt = require('jsonwebtoken'),
-  jwtConfig = sails.config.auth.jwt,
-  passport = require('passport');
+const jwt = require('jsonwebtoken');
+const jwtConfig = sails.config.auth.jwt;
+const passport = require('passport');
 module.exports = {
   friendlyName: 'Token',
   description: 'Token auth.',
@@ -10,8 +10,8 @@ module.exports = {
     }
   },
   fn: async function (inputs, exits) {
-    let req = this.req,
-      res = this.res;
+    let req = this.req;
+    let res = this.res;
     await jwt.sign({user: req.user.id}, jwtConfig.secret, jwtConfig.options, async (err, token) => {
       return exits.success({token});
     });

--- a/api/controllers/boot.js
+++ b/api/controllers/boot.js
@@ -7,10 +7,10 @@ module.exports = {
     }
   },
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      mac = String(req.param('mac') || '').replace(/[^0-9a-fA-F]/g, '').toLowerCase(),
-      host = null;
+    let req = this.req;
+    let res = this.res;
+    let mac = String(req.param('mac') || '').replace(/[^0-9a-fA-F]/g, '').toLowerCase();
+    let host = null;
 
     // Identify the host by its hardware fingerprint (issue #198), not MAC alone:
     // iPXE passes the SMBIOS values (${uuid}/${serial}/${asset}/${mac}).
@@ -26,8 +26,8 @@ module.exports = {
       if (match) { host = match.host; }
     } catch (unused) { /* fall through to anonymous menu */ }
 
-    let menus = await sails.models.pxemenu.find().sort('name ASC'),
-      lines = [];
+    let menus = await sails.models.pxemenu.find().sort('name ASC');
+    let lines = [];
 
     lines.push('#!ipxe');
     lines.push(':start');

--- a/api/controllers/general/columns.js
+++ b/api/controllers/general/columns.js
@@ -2,8 +2,8 @@ module.exports = {
   friendlyName: 'Columns',
   description: 'List datatable columns.',
   fn: async function () {
-    let req = this.req,
-      res = this.res;
+    let req = this.req;
+    let res = this.res;
     return await sails.helpers.datatables.getColumns(req, res);
   }
 };

--- a/api/controllers/general/create.js
+++ b/api/controllers/general/create.js
@@ -16,10 +16,10 @@ module.exports = {
     }
   },
   fn: async function() {
-    let req = this.req,
-      res = this.res,
-      params = req.allParams(),
-      model = params.model;
+    let req = this.req;
+    let res = this.res;
+    let params = req.allParams();
+    let model = params.model;
     // API-token requests may never write credentials (password / apiTokenHash).
     if (req.authVia === 'apitoken') { delete params.password; delete params.apiTokenHash; }
     let obj = await sails.models[model].create(params)

--- a/api/controllers/general/datatable.js
+++ b/api/controllers/general/datatable.js
@@ -2,8 +2,8 @@ module.exports = {
   friendlyName: 'Datatable',
   description: 'List datatable.',
   fn: async function () {
-    let req = this.req,
-      res = this.res;
+    let req = this.req;
+    let res = this.res;
     return await sails.helpers.datatables.getData(req, res);
   }
 };

--- a/api/controllers/general/destroy.js
+++ b/api/controllers/general/destroy.js
@@ -2,11 +2,11 @@ module.exports = {
   friendlyName: 'Destroy',
   description: 'Destroy user.',
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      params = req.allParams(),
-      id = params.id,
-      model = params.model;
+    let req = this.req;
+    let res = this.res;
+    let params = req.allParams();
+    let id = params.id;
+    let model = params.model;
     if (!Array.isArray(id)) {
       id = [id];
     }

--- a/api/controllers/general/find.js
+++ b/api/controllers/general/find.js
@@ -2,11 +2,11 @@ module.exports = {
   friendlyName: 'Find',
   description: 'Find user.',
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      params = req.allParams(),
-      model = params.model,
-      id = params.id;
+    let req = this.req;
+    let res = this.res;
+    let params = req.allParams();
+    let model = params.model;
+    let id = params.id;
     return await sails.models[model].findOne({id}).populateAll();
   }
 };

--- a/api/controllers/general/list.js
+++ b/api/controllers/general/list.js
@@ -2,10 +2,10 @@ module.exports = {
   friendlyName: 'List',
   description: 'List Items.',
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      params = req.allParams(),
-      model = params.model;
+    let req = this.req;
+    let res = this.res;
+    let params = req.allParams();
+    let model = params.model;
     return await sails.models[model].find().populateAll();
   }
 };

--- a/api/controllers/general/save.js
+++ b/api/controllers/general/save.js
@@ -10,14 +10,14 @@ module.exports = {
     }
   },
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      // Derive the model from the URL, e.g. /hosts/create -> host
-      segments = req.path.split('/').filter(Boolean),
-      plural = segments[0],
-      model = plural.replace(/s$/, ''),
-      id = req.param('id'),
-      isUpdate = !!id;
+    let req = this.req;
+    let res = this.res;
+    // Derive the model from the URL, e.g. /hosts/create -> host
+    let segments = req.path.split('/').filter(Boolean);
+    let plural = segments[0];
+    let model = plural.replace(/s$/, '');
+    let id = req.param('id');
+    let isUpdate = !!id;
 
     if (!model || !sails.models[model]) {
       res.notFound();

--- a/api/controllers/general/search.js
+++ b/api/controllers/general/search.js
@@ -2,11 +2,11 @@ module.exports = {
   friendlyName: 'Search',
   description: 'Search item',
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      params = req.allParams(),
-      query = req.query,
-      model = params.model;
+    let req = this.req;
+    let res = this.res;
+    let params = req.allParams();
+    let query = req.query;
+    let model = params.model;
     return await sails.models[model].find(query).populateAll();
   }
 };

--- a/api/controllers/general/update.js
+++ b/api/controllers/general/update.js
@@ -16,16 +16,16 @@ module.exports = {
     }
   },
   fn: async function() {
-    let req = this.req,
-      res = this.res,
-      params = req.allParams(),
-      model = params.model,
-      id = params.id;
+    let req = this.req;
+    let res = this.res;
+    let params = req.allParams();
+    let model = params.model;
+    let id = params.id;
     // API-token requests may never write credentials (password / apiTokenHash).
     if (req.authVia === 'apitoken') { delete params.password; delete params.apiTokenHash; }
-    let orig = [],
-      toRem = [],
-      obj = await sails.models[model].updateOne({id}, params)
+    let orig = [];
+    let toRem = [];
+    let obj = await sails.models[model].updateOne({id}, params)
       .intercept('E_UNIQUE', (err) => {
         return {conflict: {message: 'A record already exists with that name'}};
       })

--- a/api/controllers/host/bulk.js
+++ b/api/controllers/host/bulk.js
@@ -10,16 +10,16 @@ module.exports = {
   friendlyName: 'Bulk host update',
   description: 'Apply tag/image changes to many selected hosts.',
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      p = req.allParams(),
-      perms = req.user && req.user.permissions && req.user.permissions.stock && req.user.permissions.stock.host;
+    let req = this.req;
+    let res = this.res;
+    let p = req.allParams();
+    let perms = req.user && req.user.permissions && req.user.permissions.stock && req.user.permissions.stock.host;
 
     if (!perms || !perms.update) { return res.forbidden(); }
 
-    let toArr = (v) => (Array.isArray(v) ? v : (v ? [v] : [])).map((x) => String(x).trim()).filter(Boolean),
-      addTags = toArr(p.addTags),
-      removeTags = toArr(p.removeTags).map((t) => t.toLowerCase());
+    let toArr = (v) => (Array.isArray(v) ? v : (v ? [v] : [])).map((x) => String(x).trim()).filter(Boolean);
+    let addTags = toArr(p.addTags);
+    let removeTags = toArr(p.removeTags).map((t) => t.toLowerCase());
 
     // Resolve a requested image by name or id; '' (or null) clears it.
     let imageSet; // undefined => leave image alone
@@ -38,10 +38,11 @@ module.exports = {
     // every host matching the current list search (name/description/tags
     // substring; empty search = every host). Filtering in JS keeps the match
     // semantics predictable and avoids adapter-specific array/contains quirks.
-    let hosts, updated = 0;
+    let hosts;
+    let updated = 0;
     if (p.all) {
-      let s = String(p.search || '').trim().toLowerCase(),
-        everyHost = await sails.models.host.find();
+      let s = String(p.search || '').trim().toLowerCase();
+      let everyHost = await sails.models.host.find();
       hosts = s
         ? everyHost.filter((h) => [h.name, h.description, Array.isArray(h.tags) ? h.tags.join(' ') : '']
           .join(' ').toLowerCase().indexOf(s) !== -1)

--- a/api/controllers/host/tags.js
+++ b/api/controllers/host/tags.js
@@ -11,16 +11,16 @@ module.exports = {
   friendlyName: 'List host tags',
   description: 'Distinct tags used across all hosts.',
   fn: async function () {
-    let req = this.req,
-      res = this.res;
+    let req = this.req;
+    let res = this.res;
 
     if (!_.get(req, 'user.permissions.stock.host.read')) {
       return res.forbidden();
     }
 
-    let hosts = await sails.models.host.find().select(['tags']),
-      seen = {},
-      out = [];
+    let hosts = await sails.models.host.find().select(['tags']);
+    let seen = {};
+    let out = [];
     for (let h of hosts) {
       if (!Array.isArray(h.tags)) { continue; }
       for (let t of h.tags) {

--- a/api/controllers/image/capture.js
+++ b/api/controllers/image/capture.js
@@ -15,10 +15,10 @@ module.exports = {
     }
   },
   fn: async function (inputs, exits) {
-    let req = this.req,
-      res = this.res,
-      params = req.allParams(),
-      id = params.id;
+    let req = this.req;
+    let res = this.res;
+    let params = req.allParams();
+    let id = params.id;
     res.setTimeout(0);
     await req.file('image').upload({}, async function whenDone(err, uploadedFiles) {
       if (err) return exits.error(err);

--- a/api/controllers/image/deploy.js
+++ b/api/controllers/image/deploy.js
@@ -15,11 +15,11 @@ module.exports = {
     }
   },
   fn: async function (inputs, exits) {
-    let req = this.req,
-      res = this.res,
-      params = req.allParams(),
-      id = params.id,
-      partition = params.partition;
+    let req = this.req;
+    let res = this.res;
+    let params = req.allParams();
+    let id = params.id;
+    let partition = params.partition;
     await sails.helpers.image.stream(id, partition, res).switch({
       error: async (err) => {
         return exits.error(err);

--- a/api/controllers/image/scan.js
+++ b/api/controllers/image/scan.js
@@ -2,9 +2,9 @@ module.exports = {
   friendlyName: 'Scan image store',
   description: 'Scan the image store directory and create Image records for newly-found image folders.',
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      perms = req.user && req.user.permissions && req.user.permissions.stock && req.user.permissions.stock.image;
+    let req = this.req;
+    let res = this.res;
+    let perms = req.user && req.user.permissions && req.user.permissions.stock && req.user.permissions.stock.image;
 
     // Creating image records, so require the image create permission.
     if (!perms || !perms.create) { return res.forbidden(); }

--- a/api/controllers/pages/create/hosts.js
+++ b/api/controllers/pages/create/hosts.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
 module.exports = {
   friendlyName: 'View hosts create',
   description: 'Display "Hosts create" page.',
@@ -10,58 +10,58 @@ module.exports = {
     }
   },
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      data = {
-        model: 'host',
-        header: 'Create New Host',
-        formItems: {
-          name: {
-            textarea: false,
-            text: 'Host Name',
-            type: 'text',
-            id: 'hostname',
-            classes: ['hostname'],
-            placeholder: 'MYHOSTNAME'
-          },
-          macs: {
-            textarea: false,
-            text: 'MAC Addresses',
-            type: 'maclist',
-            id: 'macaddress',
-            classes: [],
-            value: []
-          },
-          description: {
-            textarea: true,
-            text: 'Description',
-            type: 'text',
-            id: 'hostdescription',
-            classes: [],
-            placeholder: 'Some general description'
-          },
-          tags: {
-            textarea: false,
-            text: 'Tags',
-            type: 'taginput',
-            id: 'hosttags',
-            classes: [],
-            value: []
-          }
+    let req = this.req;
+    let res = this.res;
+    let data = {
+      model: 'host',
+      header: 'Create New Host',
+      formItems: {
+        name: {
+          textarea: false,
+          text: 'Host Name',
+          type: 'text',
+          id: 'hostname',
+          classes: ['hostname'],
+          placeholder: 'MYHOSTNAME'
         },
-        formButtons: {
-          Cancel: {
-            classes: ['btn-warning','float-left'],
-            type: 'submit'
-          },
-          Create: {
-            classes: ['btn-success','float-right'],
-            type: 'submit'
-          }
+        macs: {
+          textarea: false,
+          text: 'MAC Addresses',
+          type: 'maclist',
+          id: 'macaddress',
+          classes: [],
+          value: []
         },
-        partialname: false
+        description: {
+          textarea: true,
+          text: 'Description',
+          type: 'text',
+          id: 'hostdescription',
+          classes: [],
+          placeholder: 'Some general description'
+        },
+        tags: {
+          textarea: false,
+          text: 'Tags',
+          type: 'taginput',
+          id: 'hosttags',
+          classes: [],
+          value: []
+        }
       },
-      partial = path.join(partialPath, `${data.model}.js`);
+      formButtons: {
+        Cancel: {
+          classes: ['btn-warning','float-left'],
+          type: 'submit'
+        },
+        Create: {
+          classes: ['btn-success','float-right'],
+          type: 'submit'
+        }
+      },
+      partialname: false
+    };
+    let partial = path.join(partialPath, `${data.model}.js`);
     // Offer the host's associations on the create form too (no current values).
     Object.assign(data.formItems, await sails.helpers.associationFields.with({ model: 'host', record: null }));
     // Plugin-contributed host fields (e.g. the AD plugin's tab).

--- a/api/controllers/pages/create/images.js
+++ b/api/controllers/pages/create/images.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
 module.exports = {
   friendlyName: 'View images create',
   description: 'Display "Images create" page.',
@@ -10,58 +10,58 @@ module.exports = {
     }
   },
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      data = {
-        model: 'image',
-        header: 'Create New Image',
-        formItems: {
-          name: {
-            textarea: false,
-            text: 'Image Name',
-            type: 'text',
-            id: 'imagename',
-            classes: ['imagename'],
-            placeholder: 'Golden-Image'
-          },
-          description: {
-            textarea: true,
-            text: 'Description',
-            type: 'text',
-            id: 'imagedescription',
-            classes: [],
-            placeholder: 'Some general description'
-          },
-          enabled: {
-            textarea: false,
-            text: 'Enabled',
-            type: 'checkbox',
-            id: 'imageenabled',
-            classes: [],
-            checked: true
-          },
-          protected: {
-            textarea: false,
-            text: 'Protected',
-            type: 'checkbox',
-            id: 'imageprotected',
-            classes: [],
-            checked: false
-          }
+    let req = this.req;
+    let res = this.res;
+    let data = {
+      model: 'image',
+      header: 'Create New Image',
+      formItems: {
+        name: {
+          textarea: false,
+          text: 'Image Name',
+          type: 'text',
+          id: 'imagename',
+          classes: ['imagename'],
+          placeholder: 'Golden-Image'
         },
-        formButtons: {
-          Cancel: {
-            classes: ['btn-warning','float-left'],
-            type: 'submit'
-          },
-          Create: {
-            classes: ['btn-success','float-right'],
-            type: 'submit'
-          }
+        description: {
+          textarea: true,
+          text: 'Description',
+          type: 'text',
+          id: 'imagedescription',
+          classes: [],
+          placeholder: 'Some general description'
         },
-        partialname: false
+        enabled: {
+          textarea: false,
+          text: 'Enabled',
+          type: 'checkbox',
+          id: 'imageenabled',
+          classes: [],
+          checked: true
+        },
+        protected: {
+          textarea: false,
+          text: 'Protected',
+          type: 'checkbox',
+          id: 'imageprotected',
+          classes: [],
+          checked: false
+        }
       },
-      partial = path.join(partialPath, `${data.model}.js`);
+      formButtons: {
+        Cancel: {
+          classes: ['btn-warning','float-left'],
+          type: 'submit'
+        },
+        Create: {
+          classes: ['btn-success','float-right'],
+          type: 'submit'
+        }
+      },
+      partialname: false
+    };
+    let partial = path.join(partialPath, `${data.model}.js`);
     data.title = `Create New ${data.model.charAt(0).toUpperCase() + data.model.slice(1)}`,
     data.form = await sails.helpers.formGenerator.with({
       model: data.model,

--- a/api/controllers/pages/create/pxemenus.js
+++ b/api/controllers/pages/create/pxemenus.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
 module.exports = {
   friendlyName: 'View iPXE menus create',
   description: 'Display "iPXE Menu create" page.',

--- a/api/controllers/pages/create/storagegroups.js
+++ b/api/controllers/pages/create/storagegroups.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
 module.exports = {
   friendlyName: 'View storage groups create',
   description: 'Display "Storage Group create" page.',

--- a/api/controllers/pages/create/storagenodes.js
+++ b/api/controllers/pages/create/storagenodes.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
 module.exports = {
   friendlyName: 'View storage nodes create',
   description: 'Display "Storage Node create" page.',

--- a/api/controllers/pages/create/users.js
+++ b/api/controllers/pages/create/users.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials','create');
 module.exports = {
   friendlyName: 'View users create',
   description: 'Display "users create" page.',
@@ -10,78 +10,78 @@ module.exports = {
     }
   },
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      data = {
-        model: 'user',
-        header: 'Create New User',
-        formItems: {
-          displayname: {
-            textarea: false,
-            text: 'Display Name',
-            type: 'text',
-            id: 'displayname',
-            classes: ['displayname'],
-            placeholder: 'Supercool Dude'
-          },
-          username: {
-            textarea: false,
-            text: 'Username',
-            type: 'text',
-            id: 'username',
-            classes: ['username'],
-            placeholder: 'sdude'
-          },
-          emailaddress: {
-            textarea: false,
-            text: 'Email Address',
-            type: 'text',
-            validations: {
-              minLength: 5,
-              regex: /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/
-            },
-            id: 'emailaddress',
-            classes: [],
-            placeholder: 'some@email.org'
-          },
-          password: {
-            textarea: false,
-            text: 'Password',
-            type: 'password',
-            id: 'password',
-            classes: [],
-            validations: {
-              minLength: 8,
-              regex: /(?=.*){8,}/
-            },
-            placeholder: '********'
-          },
-          passwordconf: {
-            textarea: false,
-            text: 'Password (confirm)',
-            type: 'password',
-            id: 'passwordconf',
-            classes: [],
-            validations: {
-              minLength: 8,
-              regex: /(?=.*){8,}/
-            },
-            placeholder: '********'
-          }
+    let req = this.req;
+    let res = this.res;
+    let data = {
+      model: 'user',
+      header: 'Create New User',
+      formItems: {
+        displayname: {
+          textarea: false,
+          text: 'Display Name',
+          type: 'text',
+          id: 'displayname',
+          classes: ['displayname'],
+          placeholder: 'Supercool Dude'
         },
-        formButtons: {
-          Cancel: {
-            classes: ['btn-warning','float-left'],
-            type: 'submit'
-          },
-          Create: {
-            classes: ['btn-success','float-right'],
-            type: 'submit'
-          }
+        username: {
+          textarea: false,
+          text: 'Username',
+          type: 'text',
+          id: 'username',
+          classes: ['username'],
+          placeholder: 'sdude'
         },
-        partialname: false
+        emailaddress: {
+          textarea: false,
+          text: 'Email Address',
+          type: 'text',
+          validations: {
+            minLength: 5,
+            regex: /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/
+          },
+          id: 'emailaddress',
+          classes: [],
+          placeholder: 'some@email.org'
+        },
+        password: {
+          textarea: false,
+          text: 'Password',
+          type: 'password',
+          id: 'password',
+          classes: [],
+          validations: {
+            minLength: 8,
+            regex: /(?=.*){8,}/
+          },
+          placeholder: '********'
+        },
+        passwordconf: {
+          textarea: false,
+          text: 'Password (confirm)',
+          type: 'password',
+          id: 'passwordconf',
+          classes: [],
+          validations: {
+            minLength: 8,
+            regex: /(?=.*){8,}/
+          },
+          placeholder: '********'
+        }
       },
-      partial = path.join(partialPath, `${data.model}.js`);
+      formButtons: {
+        Cancel: {
+          classes: ['btn-warning','float-left'],
+          type: 'submit'
+        },
+        Create: {
+          classes: ['btn-success','float-right'],
+          type: 'submit'
+        }
+      },
+      partialname: false
+    };
+    let partial = path.join(partialPath, `${data.model}.js`);
     data.title = `Create New ${data.model.charAt(0).toUpperCase() + data.model.slice(1)}`,
     data.form = await sails.helpers.formGenerator.with({
       model: data.model,

--- a/api/controllers/pages/dashboard.js
+++ b/api/controllers/pages/dashboard.js
@@ -1,10 +1,10 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  appRoot = path.join(__dirname, '..', '..', '..'),
-  partialPath = path.join(appRoot, 'views', 'pages', 'partials'),
-  si = require('systeminformation'),
-  moment = require('moment'),
-  checkDiskSpace = require('check-disk-space').default;
+const fs = require('fs-extra');
+const path = require('path');
+const appRoot = path.join(__dirname, '..', '..', '..');
+const partialPath = path.join(appRoot, 'views', 'pages', 'partials');
+const si = require('systeminformation');
+const moment = require('moment');
+const checkDiskSpace = require('check-disk-space').default;
 module.exports = {
   friendlyName: 'View dashboard',
   description: 'Display "Dashboard" page.',
@@ -14,13 +14,13 @@ module.exports = {
     }
   },
   fn: async function () {
-    let webserver = 'Unknown',
-      defaultInet = await si.networkInterfaceDefault(),
-      interfaces = await si.networkInterfaces(),
-      timeInfo = await si.time(),
-      uptime = moment.duration((timeInfo.uptime || 0) * 1000).humanize(),
-      load = await si.currentLoad(),
-      loadaverage = 'N/A';
+    let webserver = 'Unknown';
+    let defaultInet = await si.networkInterfaceDefault();
+    let interfaces = await si.networkInterfaces();
+    let timeInfo = await si.time();
+    let uptime = moment.duration((timeInfo.uptime || 0) * 1000).humanize();
+    let load = await si.currentLoad();
+    let loadaverage = 'N/A';
 
     // systeminformation v5: currentLoad() -> avgLoad / currentLoad (camelCase)
     if (load) {
@@ -40,8 +40,10 @@ module.exports = {
 
     // Disk usage of the image store. Fall back to the filesystem root when the
     // image path does not exist (e.g. in development).
-    let imagePath = sails.config.custom.imageStorePath || '/images',
-      free = 0, size = 0, used = 0;
+    let imagePath = sails.config.custom.imageStorePath || '/images';
+    let free = 0;
+    let size = 0;
+    let used = 0;
     try {
       let diskSpace = await checkDiskSpace(imagePath);
       size = diskSpace.size; free = diskSpace.free; used = size - free;
@@ -62,11 +64,11 @@ module.exports = {
     // is Active and not-yet-started is Staged. "Available" = open imaging slots =
     // total enabled storage-node capacity (sum of maxClients) minus what's in use.
     // (The active/staged split is provisional until the Task state enum is fixed.)
-    let active = await Task.count({ state: { '<': 5 }, progress: { '>': 0 } }),
-      staged = await Task.count({ state: { '<': 5 }, progress: 0 }),
-      storageNodes = await StorageNode.find({ isEnabled: true }),
-      capacity = storageNodes.reduce((sum, n) => sum + (Number(n.maxClients) || 0), 0),
-      avail = Math.max(0, capacity - active - staged);
+    let active = await Task.count({ state: { '<': 5 }, progress: { '>': 0 } });
+    let staged = await Task.count({ state: { '<': 5 }, progress: 0 });
+    let storageNodes = await StorageNode.find({ isEnabled: true });
+    let capacity = storageNodes.reduce((sum, n) => sum + (Number(n.maxClients) || 0), 0);
+    let avail = Math.max(0, capacity - active - staged);
 
     // Alerts panel (parity with 1.x dashboard): hosts awaiting approval.
     let pendingHosts = await Host.count({ pending: true });

--- a/api/controllers/pages/edit.js
+++ b/api/controllers/pages/edit.js
@@ -18,12 +18,12 @@ module.exports = {
     }
   },
   fn: async function () {
-    let req = this.req,
-      segments = req.path.split('/').filter(Boolean),
-      plural = segments[0],
-      model = plural.replace(/s$/, ''),
-      id = req.param('id'),
-      skip = ['id', 'createdAt', 'updatedAt', 'password', 'permissions'];
+    let req = this.req;
+    let segments = req.path.split('/').filter(Boolean);
+    let plural = segments[0];
+    let model = plural.replace(/s$/, '');
+    let id = req.param('id');
+    let skip = ['id', 'createdAt', 'updatedAt', 'password', 'permissions'];
 
     if (!model || !sails.models[model]) {
       throw 'notFound';
@@ -35,8 +35,8 @@ module.exports = {
       throw 'notFound';
     }
 
-    let attrs = sails.models[model].attributes,
-      formItems = {};
+    let attrs = sails.models[model].attributes;
+    let formItems = {};
     Object.keys(attrs).forEach((key) => {
       let attr = attrs[key];
       if (attr.collection || attr.model) { return; } // associations
@@ -70,9 +70,9 @@ module.exports = {
         return;
       }
 
-      let label = key.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase()),
-        val = record[key],
-        item = { text: label, id: `${model}-${key}`, classes: [], textarea: false };
+      let label = key.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase());
+      let val = record[key];
+      let item = { text: label, id: `${model}-${key}`, classes: [], textarea: false };
 
       if (attr.type === 'boolean') {
         item.type = 'checkbox';
@@ -98,13 +98,13 @@ module.exports = {
       Object.assign(formItems, await sails.plugins.hostForm(record));
     }
 
-    let title = model.charAt(0).toUpperCase() + model.slice(1),
-      data = {
-        model,
-        header: `Edit ${title}`,
-        title: `Edit ${title}`,
-        partialname: false
-      };
+    let title = model.charAt(0).toUpperCase() + model.slice(1);
+    let data = {
+      model,
+      header: `Edit ${title}`,
+      title: `Edit ${title}`,
+      partialname: false
+    };
     let tabOrder = await sails.helpers.formTabs.with({ model, formItems });
     data.form = await sails.helpers.formGenerator.with({
       model,

--- a/api/controllers/pages/hwinfo.js
+++ b/api/controllers/pages/hwinfo.js
@@ -7,8 +7,8 @@ module.exports = {
     }
   },
   fn: async function () {
-    let data = await sails.helpers.system.hwinfo(),
-      partialname = false;
+    let data = await sails.helpers.system.hwinfo();
+    let partialname = false;
     // Label each NIC's MAC with its IEEE OUI vendor (offline lookup).
     let MacVendor = require('../../services/MacVendor');
     if (data && data.networkInfo && Array.isArray(data.networkInfo.ifaces)) {

--- a/api/controllers/pages/list/hosts.js
+++ b/api/controllers/pages/list/hosts.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
 module.exports = {
   friendlyName: 'Hosts',
   description: 'Hosts pages.',
@@ -16,23 +16,23 @@ module.exports = {
     }
   },
   fn: async function (inputs) {
-    let req = this.req,
-      res = this.res,
-      data = {
-        header: 'Host List',
-        theads: [
-          'Host',
-          'Primary MAC',
-          'Ping Status',
-          'Last Deployed',
-          'Assigned Image',
-          'Tags',
-          'Description'
-        ],
-        model: 'host',
-        title: 'All Hosts',
-        partialname: false
-      };
+    let req = this.req;
+    let res = this.res;
+    let data = {
+      header: 'Host List',
+      theads: [
+        'Host',
+        'Primary MAC',
+        'Ping Status',
+        'Last Deployed',
+        'Assigned Image',
+        'Tags',
+        'Description'
+      ],
+      model: 'host',
+      title: 'All Hosts',
+      partialname: false
+    };
     let partial = path.join(partialPath, `${data.model}.js`);
     if (fs.existsSync(partial)) {
       data.partialname = partial;

--- a/api/controllers/pages/list/images.js
+++ b/api/controllers/pages/list/images.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
 module.exports = {
   friendlyName: 'Images',
   description: 'Images pages.',
@@ -16,20 +16,20 @@ module.exports = {
     }
   },
   fn: async function (inputs) {
-    let req = this.req,
-      res = this.res,
-      data = {
-        header: 'Image List',
-        theads: [
-          'Name',
-          'Protected',
-          'Enabled',
-          'Captured'
-        ],
-        model: 'image',
-        title: 'Image List',
-        partialname: false
-      };
+    let req = this.req;
+    let res = this.res;
+    let data = {
+      header: 'Image List',
+      theads: [
+        'Name',
+        'Protected',
+        'Enabled',
+        'Captured'
+      ],
+      model: 'image',
+      title: 'Image List',
+      partialname: false
+    };
     let partial = path.join(partialPath, `${data.model}.js`);
     if (fs.existsSync(partial)) {
       data.partialname = partial;

--- a/api/controllers/pages/list/pxemenus.js
+++ b/api/controllers/pages/list/pxemenus.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
 module.exports = {
   friendlyName: 'iPXE Menus',
   description: 'iPXE/PXE boot menu list page.',

--- a/api/controllers/pages/list/roles.js
+++ b/api/controllers/pages/list/roles.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
 module.exports = {
   friendlyName: 'Roles',
   description: 'Roles pages.',
@@ -16,19 +16,19 @@ module.exports = {
     }
   },
   fn: async function (inputs) {
-    let req = this.req,
-      res = this.res,
-      data = {
-        header: 'Role List',
-        theads: [
-          'Name',
-          'Description',
-          'Is Admin?'
-        ],
-        model: 'role',
-        title: 'Role List',
-        partialname: false
-      };
+    let req = this.req;
+    let res = this.res;
+    let data = {
+      header: 'Role List',
+      theads: [
+        'Name',
+        'Description',
+        'Is Admin?'
+      ],
+      model: 'role',
+      title: 'Role List',
+      partialname: false
+    };
     let partial = path.join(partialPath, `${data.model}.js`);
     if (fs.existsSync(partial)) {
       data.partialname = partial;

--- a/api/controllers/pages/list/storagegroups.js
+++ b/api/controllers/pages/list/storagegroups.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
 module.exports = {
   friendlyName: 'Storage Groups',
   description: 'Storage Group list page.',

--- a/api/controllers/pages/list/storagenodes.js
+++ b/api/controllers/pages/list/storagenodes.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
 module.exports = {
   friendlyName: 'Storage Nodes',
   description: 'Storage Node list page.',

--- a/api/controllers/pages/list/tasks.js
+++ b/api/controllers/pages/list/tasks.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
 module.exports = {
   friendlyName: 'Tasks',
   description: 'Tasks pages.',
@@ -16,18 +16,18 @@ module.exports = {
     }
   },
   fn: async function (inputs) {
-    let req = this.req,
-      res = this.res,
-      data = {
-        header: 'Task List',
-        theads: [
-          'Title',
-          'Description'
-        ],
-        model: 'task',
-        title: 'Task List',
-        partialname: false
-      };
+    let req = this.req;
+    let res = this.res;
+    let data = {
+      header: 'Task List',
+      theads: [
+        'Title',
+        'Description'
+      ],
+      model: 'task',
+      title: 'Task List',
+      partialname: false
+    };
     let partial = path.join(partialPath, `${data.model}.js`);
     if (fs.existsSync(partial)) {
       data.partialname = partial;

--- a/api/controllers/pages/list/users.js
+++ b/api/controllers/pages/list/users.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
 module.exports = {
   friendlyName: 'Users',
   description: 'Users pages.',
@@ -16,19 +16,19 @@ module.exports = {
     }
   },
   fn: async function (inputs) {
-    let req = this.req,
-      res = this.res,
-      data = {
-        header: 'User List',
-        theads: [
-          'Display Name',
-          'Username',
-          'Email'
-        ],
-        model: 'user',
-        title: 'User List',
-        partialname: false
-      };
+    let req = this.req;
+    let res = this.res;
+    let data = {
+      header: 'User List',
+      theads: [
+        'Display Name',
+        'Username',
+        'Email'
+      ],
+      model: 'user',
+      title: 'User List',
+      partialname: false
+    };
     let partial = path.join(partialPath, `${data.model}.js`);
     if (fs.existsSync(partial)) {
       data.partialname = partial;

--- a/api/controllers/pages/list/workflows.js
+++ b/api/controllers/pages/list/workflows.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname,'..','..','..','..','views','pages','partials','list');
 module.exports = {
   friendlyName: 'Workflows',
   description: 'Workflows pages.',
@@ -16,18 +16,18 @@ module.exports = {
     }
   },
   fn: async function (inputs) {
-    let req = this.req,
-      res = this.res,
-      data = {
-        header: 'Workflow List',
-        theads: [
-          'Name',
-          'Description'
-        ],
-        model: 'workflow',
-        title: 'Workflow List',
-        partialname: false
-      };
+    let req = this.req;
+    let res = this.res;
+    let data = {
+      header: 'Workflow List',
+      theads: [
+        'Name',
+        'Description'
+      ],
+      model: 'workflow',
+      title: 'Workflow List',
+      partialname: false
+    };
     let partial = path.join(partialPath, `${data.model}.js`);
     if (fs.existsSync(partial)) {
       data.partialname = partial;

--- a/api/controllers/pages/login.js
+++ b/api/controllers/pages/login.js
@@ -1,6 +1,6 @@
-const fs = require('fs-extra'),
-  path = require('path'),
-  partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials');
+const fs = require('fs-extra');
+const path = require('path');
+const partialPath = path.join(__dirname, '..', '..', '..','views','pages','partials');
 module.exports = {
   friendlyName: 'View login',
   description: 'Display "Login" page.',

--- a/api/controllers/pages/search.js
+++ b/api/controllers/pages/search.js
@@ -7,12 +7,12 @@ module.exports = {
     }
   },
   fn: async function () {
-    let req = this.req,
-      q = req.param('q') || '',
-      groups = await sails.helpers.globalSearch.with({
-        q,
-        permissions: _.get(req, 'user.permissions') || {}
-      });
+    let req = this.req;
+    let q = req.param('q') || '';
+    let groups = await sails.helpers.globalSearch.with({
+      q,
+      permissions: _.get(req, 'user.permissions') || {}
+    });
     return {
       title: q ? `Search: ${q}` : 'Search',
       header: q ? `Search results for "${q}"` : 'Search',

--- a/api/controllers/role/assign.js
+++ b/api/controllers/role/assign.js
@@ -2,11 +2,11 @@ module.exports = {
   friendlyName: 'Assign',
   description: 'Assign users to this role.',
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      params = req.allParams(),
-      id = params.id,
-      users = params.users;
+    let req = this.req;
+    let res = this.res;
+    let params = req.allParams();
+    let id = params.id;
+    let users = params.users;
     await Role.addToCollection(id, 'users', users);
     return await Role.findOne({id}).populateAll();
   }

--- a/api/controllers/role/unassign.js
+++ b/api/controllers/role/unassign.js
@@ -2,11 +2,11 @@ module.exports = {
   friendlyName: 'Unassign',
   description: 'Unassign users from this role.',
   fn: async function () {
-    let req = this.req,
-      res = this.res,
-      params = req.allParams(),
-      id = params.id,
-      users = params.users;
+    let req = this.req;
+    let res = this.res;
+    let params = req.allParams();
+    let id = params.id;
+    let users = params.users;
     await Role.removeFromCollection(id, 'users', users);
     return await Role.findOne({id}).populateAll();
   }

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -2,8 +2,8 @@ module.exports = {
   friendlyName: 'Search (API)',
   description: 'Global search across user-facing models (JSON), filtered by read permissions.',
   fn: async function () {
-    let req = this.req,
-      q = req.param('q') || '';
+    let req = this.req;
+    let q = req.param('q') || '';
     return await sails.helpers.globalSearch.with({
       q,
       permissions: _.get(req, 'user.permissions') || {}

--- a/api/controllers/system/bandwidth.js
+++ b/api/controllers/system/bandwidth.js
@@ -1,5 +1,5 @@
-const si = require('systeminformation'),
-  moment = require('moment');
+const si = require('systeminformation');
+const moment = require('moment');
 module.exports = {
   friendlyName: 'Bandwidth',
   description: 'Bandwidth system.',
@@ -8,8 +8,8 @@ module.exports = {
   exits: {
   },
   fn: async function (inputs) {
-    let default_iface = await si.networkInterfaceDefault(),
-      netstats = await si.networkStats(default_iface);
+    let default_iface = await si.networkInterfaceDefault();
+    let netstats = await si.networkStats(default_iface);
     return {
       default_iface,
       netstats

--- a/api/controllers/system/info.js
+++ b/api/controllers/system/info.js
@@ -1,5 +1,5 @@
-const si = require('systeminformation'),
-  moment = require('moment');
+const si = require('systeminformation');
+const moment = require('moment');
 module.exports = {
   friendlyName: 'Info',
   description: 'Info system.',
@@ -11,18 +11,18 @@ module.exports = {
     let options = {
       time: 'uptime',
       currentLoad: 'currentLoadUser, currentLoadSystem, currentLoadIdle',
-    },
-      sysinfo = await si.get(options),
-      user = (sysinfo.currentLoad.currentLoadUser || 0).toFixed(2),
-      sys = (sysinfo.currentLoad.currentLoadSystem || 0).toFixed(2),
-      idle = (sysinfo.currentLoad.currentLoadIdle || 0).toFixed(2),
-      upsecs = sysinfo.time.uptime * 1000,
-      durr = moment.duration(upsecs),
-      uptime = durr.humanize(),
-      loadaverage = `User: ${user}, Sys: ${sys}, Idle: ${idle}`;
+    };
+    let sysinfo = await si.get(options);
+    let user = (sysinfo.currentLoad.currentLoadUser || 0).toFixed(2);
+    let sys = (sysinfo.currentLoad.currentLoadSystem || 0).toFixed(2);
+    let idle = (sysinfo.currentLoad.currentLoadIdle || 0).toFixed(2);
+    let upsecs = sysinfo.time.uptime * 1000;
+    let durr = moment.duration(upsecs);
+    let uptime = durr.humanize();
+    let loadaverage = `User: ${user}, Sys: ${sys}, Idle: ${idle}`;
     return {
       uptime,
       loadaverage
-    }
+    };
   }
 };

--- a/api/controllers/task-history.js
+++ b/api/controllers/task-history.js
@@ -10,23 +10,23 @@ module.exports = {
     }
   },
   fn: async function (inputs) {
-    let data = [],
-      dates = [],
-      dateStart = await moment().subtract(inputs.period, 'days'),
-      dateEnd = await moment();
+    let data = [];
+    let dates = [];
+    let dateStart = await moment().subtract(inputs.period, 'days');
+    let dateEnd = await moment();
 
     while (dateEnd.diff(dateStart, 'days') >= 0) {
-      let begin = await moment(dateStart.format('YYYY-MM-DD')).toISOString(),
-        end = await moment(dateStart.format('YYYY-MM-DD')).add(1, 'day').toISOString(),
-        taskQuery = {
-          startTime: {
-            '>=': begin,
-            '<': end
-          },
-          state: {
-            '<': 5
-          }
-        };
+      let begin = await moment(dateStart.format('YYYY-MM-DD')).toISOString();
+      let end = await moment(dateStart.format('YYYY-MM-DD')).add(1, 'day').toISOString();
+      let taskQuery = {
+        startTime: {
+          '>=': begin,
+          '<': end
+        },
+        state: {
+          '<': 5
+        }
+      };
       dates.push(dateStart.format('MM/DD/YYYY'));
       data.push(parseInt(await Task.count(taskQuery), 10));
       dateStart.add(1, 'day');

--- a/api/controllers/user/reset-api-token.js
+++ b/api/controllers/user/reset-api-token.js
@@ -16,8 +16,8 @@ module.exports = {
     if (!_.get(req, 'user.permissions.stock.user.update')) return exits.forbidden();
     let target = await User.findOne({ id: inputs.id });
     if (!target) return exits.notFound();
-    let token = 'fpat_' + crypto.randomBytes(24).toString('hex'),
-      hash = crypto.createHash('sha256').update(token).digest('hex');
+    let token = 'fpat_' + crypto.randomBytes(24).toString('hex');
+    let hash = crypto.createHash('sha256').update(token).digest('hex');
     await User.updateOne({ id: inputs.id }).set({ apiTokenHash: hash });
     // The plaintext token is returned exactly once; we keep only the hash.
     return exits.success({ ok: true, token });

--- a/api/controllers/user/reset-password.js
+++ b/api/controllers/user/reset-password.js
@@ -1,6 +1,6 @@
 module.exports = {
   friendlyName: 'Reset password',
-  description: "Admin: set a new password for another user. Web session only -- never via an API token.",
+  description: 'Admin: set a new password for another user. Web session only -- never via an API token.',
   inputs: {
     id: { type: 'string', required: true, description: 'Target user id.' },
     password: { type: 'string', required: true, minLength: 8 },

--- a/api/helpers/association-fields.js
+++ b/api/helpers/association-fields.js
@@ -26,10 +26,10 @@ module.exports = {
     if (!Model) {
       return {};
     }
-    let attrs = Model.attributes,
-      record = inputs.record || {},
-      skip = inputs.skip || [],
-      out = {};
+    let attrs = Model.attributes;
+    let record = inputs.record || {};
+    let skip = inputs.skip || [];
+    let out = {};
 
     for (let key of Object.keys(attrs)) {
       let attr = attrs[key];
@@ -37,11 +37,11 @@ module.exports = {
       let targetIdentity = attr.model || attr.collection;
       if (!targetIdentity || !sails.models[targetIdentity]) { continue; }
 
-      let Target = sails.models[targetIdentity],
-        sortKey = Target.attributes.name ? 'name ASC' : (Target.attributes.username ? 'username ASC' : 'createdAt ASC'),
-        candidates = await Target.find().sort(sortKey),
-        label = key.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase()),
-        labelOf = (c) => c.name || c.username || c.id;
+      let Target = sails.models[targetIdentity];
+      let sortKey = Target.attributes.name ? 'name ASC' : (Target.attributes.username ? 'username ASC' : 'createdAt ASC');
+      let candidates = await Target.find().sort(sortKey);
+      let label = key.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase());
+      let labelOf = (c) => c.name || c.username || c.id;
 
       if (attr.model) {
         let curId = (record[key] && (record[key].id || record[key])) || null;

--- a/api/helpers/datatables/get-columns.js
+++ b/api/helpers/datatables/get-columns.js
@@ -20,10 +20,10 @@ module.exports = {
     }
   },
   fn: async function (inputs) {
-    let req = inputs.req,
-      res = inputs.res,
-      params = req.allParams(),
-      model = params.model;
+    let req = inputs.req;
+    let res = inputs.res;
+    let params = req.allParams();
+    let model = params.model;
 
     if (!model || !sails.models[model]) {
       return {

--- a/api/helpers/datatables/get-data.js
+++ b/api/helpers/datatables/get-data.js
@@ -20,11 +20,11 @@ module.exports = {
     }
   },
   fn: async function (inputs, exits) {
-    var req = inputs.req,
-      res = inputs.res,
-      params = req.allParams(),
-      model = params.model,
-      options = params.options || params || {};
+    var req = inputs.req;
+    var res = inputs.res;
+    var params = req.allParams();
+    var model = params.model;
+    var options = params.options || params || {};
 
     if (!model || !sails.models[model]) {
       return {
@@ -83,10 +83,10 @@ module.exports = {
     var _reverse = {};
 
     // Build where Criteria
-    var where = [],
-      whereQuery = {or: []},
-      select = [],
-      order = [];
+    var where = [];
+    var whereQuery = {or: []};
+    var select = [];
+    var order = [];
 
     if (_.isArray(_options.columns)) {
       _options.columns.forEach((column, index) => {
@@ -97,8 +97,8 @@ module.exports = {
         }
         if (false === columnType || 'boolean' === columnType) return true;
         if (_.isBoolean(column.reverse)) {
-          var joinedModel = _.split(column.data, '.', 2)[0],
-            association = _.find(model.associations, ['alias', joinedModel]);
+          var joinedModel = _.split(column.data, '.', 2)[0];
+          var association = _.find(model.associations, ['alias', joinedModel]);
           if (_.isUndefined(association)) {
             _response.error = `Association ${joinedModel} not found on this model: ${model.identity}`;
             return true;

--- a/api/helpers/form-generator.js
+++ b/api/helpers/form-generator.js
@@ -29,22 +29,29 @@ module.exports = {
     success: { description: 'All done.' }
   },
   fn: async function (inputs) {
-    let model = inputs.model,
-      formType = inputs.formType,
-      method = (inputs.method || 'post').toLowerCase() === 'get' ? 'get' : 'post',
-      action = inputs.action,
-      id = inputs.id,
-      classes = inputs.classes,
-      formItems = inputs.formItems,
-      formButtons = inputs.formButtons,
-      tabOrder = inputs.tabOrder || [];
+    let model = inputs.model;
+    let formType = inputs.formType;
+    let method = (inputs.method || 'post').toLowerCase() === 'get' ? 'get' : 'post';
+    let action = inputs.action;
+    let id = inputs.id;
+    let classes = inputs.classes;
+    let formItems = inputs.formItems;
+    let formButtons = inputs.formButtons;
+    let tabOrder = inputs.tabOrder || [];
 
     // Render a single form item to its HTML string.
     function renderField(item, input, obj) {
-      let iChecked = '', iId = '', iFor = '', iClass = '', iValue = '',
-        iPlaceholder = '', iMaxlength = '', iMinlength = '', iRegex = '',
-        iName = ` name="${item}"`,
-        field = '';
+      let iChecked = '';
+      let iId = '';
+      let iFor = '';
+      let iClass = '';
+      let iValue = '';
+      let iPlaceholder = '';
+      let iMaxlength = '';
+      let iMinlength = '';
+      let iRegex = '';
+      let iName = ` name="${item}"`;
+      let field = '';
       if (input.id) {
         iFor = ` for="${input.id}"`;
         iId = ` id="${input.id}"`;
@@ -214,11 +221,12 @@ module.exports = {
     }
 
     // Group rendered fields into tab buckets (by each item's `tab`, default General).
-    let buckets = {}, seen = [];
+    let buckets = {};
+    let seen = [];
     for (let item in formItems) {
-      let input = formItems[item],
-        obj = sails.models[model].attributes[item],
-        tab = input.tab || 'General';
+      let input = formItems[item];
+      let obj = sails.models[model].attributes[item];
+      let tab = input.tab || 'General';
       if (!buckets[tab]) { buckets[tab] = ''; seen.push(tab); }
       buckets[tab] += renderField(item, input, obj);
     }

--- a/api/helpers/form-tabs.js
+++ b/api/helpers/form-tabs.js
@@ -25,8 +25,8 @@ module.exports = {
     success: { outputFriendlyName: 'Tab order' }
   },
   fn: async function (inputs) {
-    let model = inputs.model,
-      formItems = inputs.formItems || {};
+    let model = inputs.model;
+    let formItems = inputs.formItems || {};
 
     if (model === 'host') {
       Object.keys(formItems).forEach((k) => {

--- a/api/helpers/global-search.js
+++ b/api/helpers/global-search.js
@@ -22,9 +22,9 @@ module.exports = {
     }
   },
   fn: async function (inputs) {
-    let q = (inputs.q || '').trim(),
-      perms = inputs.permissions || {},
-      groups = [];
+    let q = (inputs.q || '').trim();
+    let perms = inputs.permissions || {};
+    let groups = [];
 
     if (!q) {
       return groups;
@@ -32,14 +32,14 @@ module.exports = {
 
     // Escape the query so it is matched as a literal substring (no regex
     // injection / ReDoS from user input), then match case-insensitively.
-    let escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
-      escaped = escapeRe(q);
+    let escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    let escaped = escapeRe(q);
 
     // MACs are stored as bare lower-case hex with no separators (e.g.
     // "aabbccddeeff"), so strip any colon/hyphen/dot/space the user typed first
     // -- lets "aa:bb:cc", "AA-BB-CC" and "aabbcc" all match the `macs` array.
-    let macStripped = q.replace(/[\s.:-]/g, ''),
-      macEscaped = macStripped ? escapeRe(macStripped) : '';
+    let macStripped = q.replace(/[\s.:-]/g, '');
+    let macEscaped = macStripped ? escapeRe(macStripped) : '';
 
     // The user-facing entities and which string fields to search. Hosts also
     // match on their hardware identifiers (macs/serial/asset/guid) and their
@@ -72,9 +72,9 @@ module.exports = {
       try {
         // Use the native Mongo collection for a case-insensitive regex search
         // (Waterline's `contains` is case-sensitive under sails-mongo).
-        let db = sails.getDatastore(Model.datastore).manager,
-          collection = db.collection(Model.tableName),
-          or = [];
+        let db = sails.getDatastore(Model.datastore).manager;
+        let collection = db.collection(Model.tableName);
+        let or = [];
         for (let f of fields) {
           if (f === 'macs') {
             // Only search the bare-hex array when the stripped query still has

--- a/api/helpers/identify-host.js
+++ b/api/helpers/identify-host.js
@@ -38,12 +38,12 @@ module.exports = {
     success: { outputFriendlyName: 'Match', description: 'null, or { host, score, signals }.' }
   },
   fn: async function (inputs) {
-    let fp = inputs.fingerprint || {},
-      guid = norm(fp.guid || fp.uuid),
-      serial = norm(fp.serial),
-      asset = norm(fp.asset),
-      macsIn = fp.macs || fp.mac || [],
-      macs = (Array.isArray(macsIn) ? macsIn : [macsIn]).map(normMac).filter(Boolean);
+    let fp = inputs.fingerprint || {};
+    let guid = norm(fp.guid || fp.uuid);
+    let serial = norm(fp.serial);
+    let asset = norm(fp.asset);
+    let macsIn = fp.macs || fp.mac || [];
+    let macs = (Array.isArray(macsIn) ? macsIn : [macsIn]).map(normMac).filter(Boolean);
 
     // Build a query that fetches only the hosts sharing at least one signal.
     let or = [];
@@ -53,12 +53,13 @@ module.exports = {
     if (macs.length) { or.push({ macs: { $in: macs } }); }
     if (!or.length) { return null; }
 
-    let coll = sails.getDatastore(sails.models.host.datastore).manager.collection(sails.models.host.tableName),
-      candidates = await coll.find({ $or: or }).toArray();
+    let coll = sails.getDatastore(sails.models.host.datastore).manager.collection(sails.models.host.tableName);
+    let candidates = await coll.find({ $or: or }).toArray();
 
     let best = null;
     for (let c of candidates) {
-      let score = 0, signals = [];
+      let score = 0;
+      let signals = [];
       if (guid && norm(c.guid) === guid) { score += WEIGHTS.guid; signals.push('guid'); }
       if (serial && norm(c.serial) === serial) { score += WEIGHTS.serial; signals.push('serial'); }
       if (asset && norm(c.asset) === asset) { score += WEIGHTS.asset; signals.push('asset'); }

--- a/api/helpers/image/aquire-read-lock.js
+++ b/api/helpers/image/aquire-read-lock.js
@@ -22,8 +22,8 @@ module.exports = {
     },
   },
   fn: async function (inputs, exits) {
-    let id = inputs.id,
-      db = Image.getDatastore().manager;
+    let id = inputs.id;
+    let db = Image.getDatastore().manager;
     await db.collection(Image.tableName).update({_id: new ObjectId(id), writeLock: false}, {$inc: {readers: 1}}, async (err, image) => {
       if (err) return exits.error(err);
       if (!image) return exits.invalid('Image not found');

--- a/api/helpers/image/aquire-write-lock.js
+++ b/api/helpers/image/aquire-write-lock.js
@@ -22,8 +22,8 @@ module.exports = {
     },
   },
   fn: async function (inputs, exits) {
-    let id = inputs.id,
-      db = Image.getDatastore().manager;
+    let id = inputs.id;
+    let db = Image.getDatastore().manager;
     await db.collection(Image.tableName).update({_id: new ObjectId(id), writeLock: false, readers: 0}, {$set: {writeLock: true}}, async(err, image) => {
       if (err) return exits.error(err);
       if (!image) return exits.invalid('Image not found');

--- a/api/helpers/image/scan-store.js
+++ b/api/helpers/image/scan-store.js
@@ -1,5 +1,5 @@
-const fs = require('fs'),
-  path = require('path');
+const fs = require('fs');
+const path = require('path');
 
 module.exports = {
   friendlyName: 'Scan image store',
@@ -12,10 +12,10 @@ module.exports = {
     success: { outputFriendlyName: 'Scan result' }
   },
   fn: async function () {
-    let dir = sails.config.custom.imageStorePath || '/images',
-      // FOG system dirs that live under the store but are not images.
-      skip = ['dev', 'lost+found', 'postdownloadscripts', 'postinitscripts'],
-      result = { path: dir, found: [], created: [], skipped: [] };
+    let dir = sails.config.custom.imageStorePath || '/images';
+    // FOG system dirs that live under the store but are not images.
+    let skip = ['dev', 'lost+found', 'postdownloadscripts', 'postinitscripts'];
+    let result = { path: dir, found: [], created: [], skipped: [] };
 
     let entries;
     try {

--- a/api/helpers/image/stream.js
+++ b/api/helpers/image/stream.js
@@ -1,6 +1,6 @@
-const path = require('path'),
-  fs = require('fs'),
-  progress = require('progress-stream');
+const path = require('path');
+const fs = require('fs');
+const progress = require('progress-stream');
 module.exports = {
   friendlyName: 'Stream',
   description: 'Stream image.',
@@ -36,10 +36,10 @@ module.exports = {
     },
   },
   fn: async function (inputs, exits) {
-    let id = inputs.id,
-      partition = inputs.partition,
-      target = inputs.target,
-      imageDir = sails.config.custom.imageStorePath || '/images';
+    let id = inputs.id;
+    let partition = inputs.partition;
+    let target = inputs.target;
+    let imageDir = sails.config.custom.imageStorePath || '/images';
     await sails.helpers.image.aquireReadLock(id).switch({
       error: async (err) => {
         return exits.error(err);
@@ -56,8 +56,8 @@ module.exports = {
           fs.stat(partitionPath, (err, stat) => {
             if (err) return exits.error(err);
             if (!stat) return exits.invalid('Cannot get status of file');
-            let stream = fs.createReadStream(partitionPath),
-              progressStream = progress({length: stat.size, time: 100});
+            let stream = fs.createReadStream(partitionPath);
+            let progressStream = progress({length: stat.size, time: 100});
             stream.on('error', (err) => {
               if (err) return exits.error(err);
             });

--- a/api/helpers/system/hwinfo.js
+++ b/api/helpers/system/hwinfo.js
@@ -1,9 +1,9 @@
-const si = require('systeminformation'),
-  fs = require('fs-extra'),
-  path = require('path'),
-  appRoot = path.join(__dirname, '..', '..', '..'),
-  moment = require('moment'),
-  checkDiskSpace = require('check-disk-space').default;
+const si = require('systeminformation');
+const fs = require('fs-extra');
+const path = require('path');
+const appRoot = path.join(__dirname, '..', '..', '..');
+const moment = require('moment');
+const checkDiskSpace = require('check-disk-space').default;
 module.exports = {
   friendlyName: 'Hwinfo',
   description: 'Hwinfo system.',
@@ -15,31 +15,31 @@ module.exports = {
     },
   },
   fn: async function (inputs) {
-    let default_iface = await si.networkInterfaceDefault(),
-      network_ifaces = await si.networkInterfaces(),
-      ifaces = [],
-      serverip,
-      sysinfo = await si.get({
-        cpu: 'vendor, brand, physicalCores, speed, cache',
-        mem: 'total, free, used',
-        time: 'uptime',
-        currentLoad: 'currentLoadUser, currentLoadSystem, currentLoadIdle',
-        osInfo: 'hostname'
-      }),
-      user = (sysinfo.currentLoad.currentLoadUser || 0).toFixed(2),
-      sys = (sysinfo.currentLoad.currentLoadSystem || 0).toFixed(2),
-      idle = (sysinfo.currentLoad.currentLoadIdle || 0).toFixed(2),
-      upsecs = sysinfo.time.uptime * 1000,
-      durr = moment.duration(upsecs),
-      uptime = durr.humanize(),
-      hostname = sysinfo.osInfo.hostname
-      loadaverage = `User: ${user}, Sys: ${sys}, Idle: ${idle}`,
-      cpu = sysinfo.cpu,
-      memory = sysinfo.mem,
-      size = {},
-      setIfaces = ifaceitem => {
-        ifaces.push(ifaceitem);
-      };
+    let default_iface = await si.networkInterfaceDefault();
+    let network_ifaces = await si.networkInterfaces();
+    let ifaces = [];
+    let serverip;
+    let sysinfo = await si.get({
+      cpu: 'vendor, brand, physicalCores, speed, cache',
+      mem: 'total, free, used',
+      time: 'uptime',
+      currentLoad: 'currentLoadUser, currentLoadSystem, currentLoadIdle',
+      osInfo: 'hostname'
+    });
+    let user = (sysinfo.currentLoad.currentLoadUser || 0).toFixed(2);
+    let sys = (sysinfo.currentLoad.currentLoadSystem || 0).toFixed(2);
+    let idle = (sysinfo.currentLoad.currentLoadIdle || 0).toFixed(2);
+    let upsecs = sysinfo.time.uptime * 1000;
+    let durr = moment.duration(upsecs);
+    let uptime = durr.humanize();
+    let hostname = sysinfo.osInfo.hostname;
+    loadaverage = `User: ${user}, Sys: ${sys}, Idle: ${idle}`,
+    cpu = sysinfo.cpu,
+    memory = sysinfo.mem,
+    size = {},
+    setIfaces = ifaceitem => {
+      ifaces.push(ifaceitem);
+    };
     // General information
     Object.keys(cpu.cache).forEach(async key => {
       cpu.cache[key] = await sails.helpers.readableBytes(cpu.cache[key]);
@@ -51,9 +51,9 @@ module.exports = {
     // Filesystem info
     let imagePath = sails.config.custom.imageStorePath || '/images';
     size = await checkDiskSpace(imagePath).then(async diskspace => {
-      let free = diskspace.free,
-        total = diskspace.size,
-        used = total - free;
+      let free = diskspace.free;
+      let total = diskspace.size;
+      let used = total - free;
       return {
         path: diskspace.diskPath,
         total: await sails.helpers.readableBytes(total),
@@ -63,7 +63,7 @@ module.exports = {
     });
 
     // Network information
-    for (var i = 0;i < network_ifaces.length; i++) {
+    for (var i = 0; i < network_ifaces.length; i++) {
       iface = network_ifaces[i];
       if (default_iface === iface.iface) {
         serverip = iface.ip4;

--- a/api/hooks/fog-version/index.js
+++ b/api/hooks/fog-version/index.js
@@ -4,21 +4,21 @@
  * @description :: A hook definition.  Extends Sails by adding shadow routes, implicit actions, and/or initialization logic.
  * @docs        :: https://sailsjs.com/docs/concepts/extending-sails/hooks
  */
-const path = require('path'),
-  fs = require('fs'),
-  appPath = path.join(__dirname, '..', '..', '..'),
-  pkgPath = path.join(appPath, 'package.json'),
-  safeReadJSON = filepath => {
-    if (!fs.existsSync(filepath)) return {};
-    let raw;
-    try {
-      raw = fs.readFileSync(filepath, 'utf8');
-    } catch (err) {
-      console.log(err);
-      return {};
-    }
-    return JSON.parse(raw) || {};
-  };
+const path = require('path');
+const fs = require('fs');
+const appPath = path.join(__dirname, '..', '..', '..');
+const pkgPath = path.join(appPath, 'package.json');
+const safeReadJSON = filepath => {
+  if (!fs.existsSync(filepath)) return {};
+  let raw;
+  try {
+    raw = fs.readFileSync(filepath, 'utf8');
+  } catch (err) {
+    console.log(err);
+    return {};
+  }
+  return JSON.parse(raw) || {};
+};
 module.exports = function defineFogVersionHook(sails) {
   return {
     routes: {

--- a/api/hooks/plugins/index.js
+++ b/api/hooks/plugins/index.js
@@ -18,19 +18,19 @@
  *
  * @docs :: https://sailsjs.com/docs/concepts/extending-sails/hooks
  */
-const path = require('path'),
-  fs = require('fs');
+const path = require('path');
+const fs = require('fs');
 
 module.exports = function definePluginsHook(sails) {
-  let appRoot = path.join(__dirname, '..', '..', '..'),
-    routes = {},
-    menuItems = [],
-    hostExtensions = [],
-    models = {},
-    permissions = {},
-    search = [],
-    loaded = [],
-    loadError = null;
+  let appRoot = path.join(__dirname, '..', '..', '..');
+  let routes = {};
+  let menuItems = [];
+  let hostExtensions = [];
+  let models = {};
+  let permissions = {};
+  let search = [];
+  let loaded = [];
+  let loadError = null;
 
   try {
     let cfg = JSON.parse(fs.readFileSync(path.join(appRoot, 'plugins.json'), 'utf8'));

--- a/api/hooks/watchdog/index.js
+++ b/api/hooks/watchdog/index.js
@@ -4,8 +4,8 @@
  * @description :: A hook definition.  Extends Sails by adding shadow routes, implicit actions, and/or initialization logic.
  * @docs        :: https://sailsjs.com/docs/concepts/extending-sails/hooks
  */
-const delay = 1 * 60 * 1000,
-  async = require('async');
+const delay = 1 * 60 * 1000;
+const async = require('async');
 var running = false;
 module.exports = function defineWatchdogHook(sails) {
   return {

--- a/api/models/Host.js
+++ b/api/models/Host.js
@@ -57,7 +57,8 @@ function normalizeTags(values) {
   if (!Array.isArray(raw)) {
     raw = (raw === null || typeof raw === 'undefined') ? [] : [raw];
   }
-  let out = [], seen = {};
+  let out = [];
+  let seen = {};
   for (let entry of raw) {
     if (entry === null || typeof entry === 'undefined') { continue; }
     let tag = String(entry).trim();

--- a/api/models/Role.js
+++ b/api/models/Role.js
@@ -4,37 +4,37 @@
  * @description :: A model definition represents a database table/collection.
  * @docs        :: https://sailsjs.com/docs/concepts/models-and-orm/models
  */
-const flatten = require('flat'),
-  filterPermissions = function(permissions) {
-    if (!permissions) permissions = {};
-    let toValidate = flatten(permissions);
+const flatten = require('flat');
+const filterPermissions = function(permissions) {
+  if (!permissions) permissions = {};
+  let toValidate = flatten(permissions);
 
-    // Filter out unknown permissions
-    for (var i = 0; i < toValidate.length; i++) {
-      if (!_.get(sails.config.permissions, toValidate[i])) _.set(permissions, toValidate[i], undefined);
+  // Filter out unknown permissions
+  for (var i = 0; i < toValidate.length; i++) {
+    if (!_.get(sails.config.permissions, toValidate[i])) _.set(permissions, toValidate[i], undefined);
+  }
+
+  // Merge in the default permissions, ensuring all values are set
+  // Note that the 'right' object being merged overrides any values set
+  // by the 'left' object.
+  return _.extend(sails.config.permissions, permissions);
+};
+const deepMap = function(obj, cb) {
+  let out = {};
+
+  Object.keys(obj).forEach((k) => {
+    let val;
+    if (obj[k] !== null && typeof obj[k] === 'object') {
+      val = deepMap(obj[k], cb);
+    } else {
+      val = cb(obj[k], k);
     }
 
-    // Merge in the default permissions, ensuring all values are set
-    // Note that the 'right' object being merged overrides any values set
-    // by the 'left' object.
-    return _.extend(sails.config.permissions, permissions);
-  },
-  deepMap = function(obj, cb) {
-    let out = {};
+    out[k] = val;
+  });
 
-    Object.keys(obj).forEach(function(k) {
-      let val;
-      if (obj[k] !== null && typeof obj[k] === 'object') {
-        val = deepMap(obj[k], cb);
-      } else {
-        val = cb(obj[k], k);
-      }
-
-      out[k] = val;
-    });
-
-    return out;
-  };
+  return out;
+};
 module.exports = {
   attributes: {
     name: {
@@ -61,7 +61,7 @@ module.exports = {
   },
   customToJSON: function() {
     if (this.isAdmin) {
-      this.permissions = deepMap(sails.config.permissions, function(v, k) {
+      this.permissions = deepMap(sails.config.permissions, (v, k) => {
         return true;
       });
     } else {
@@ -71,7 +71,7 @@ module.exports = {
   },
   beforeCreate: function(values, next) {
     if (values.isAdmin) {
-      values.permissions = deepMap(sails.config.permissions, function(v, k) {
+      values.permissions = deepMap(sails.config.permissions, (v, k) => {
         return true;
       });
     } else {
@@ -84,7 +84,7 @@ module.exports = {
     if (values.hasOwnProperty('permissions') && !values.isAdmin) {
       values.permissions = filterPermissions(values.permissions);
     } else if (values.isAdmin) {
-      values.permissions = deepMap(sails.config.permissions, function(v, k) {
+      values.permissions = deepMap(sails.config.permissions, (v, k) => {
         return true;
       });
     }

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -4,33 +4,33 @@
  * @description :: A model definition represents a database table/collection.
  * @docs        :: https://sailsjs.com/docs/concepts/models-and-orm/models
  */
-const bcrypt = require('bcryptjs'),
-  flatten = require('flat'),
-  filterPermissions = function(permissions) {
-    if (!permissions) permissions = {};
-    let toValidate = flatten(permissions);
-    // Filter out unknown permissions
-    for (var i = 0; i < toValidate.length; i++) {
-      if (!_.get(sails.config.permissions, toValidate[i])) _.set(permissions, toValidate[i], undefined);
+const bcrypt = require('bcryptjs');
+const flatten = require('flat');
+const filterPermissions = function(permissions) {
+  if (!permissions) permissions = {};
+  let toValidate = flatten(permissions);
+  // Filter out unknown permissions
+  for (var i = 0; i < toValidate.length; i++) {
+    if (!_.get(sails.config.permissions, toValidate[i])) _.set(permissions, toValidate[i], undefined);
+  }
+  // Merge in the default permissions, ensuring all values are set
+  // Note that the 'right' object being merged overrides any values set
+  // by the 'left' object.
+  return _.extend(sails.config.permissions, permissions);
+};
+const deepMap = function(obj, cb) {
+  let out = {};
+  Object.keys(obj).forEach((k) => {
+    let val;
+    if (obj[k] !== null && typeof obj[k] === 'object') {
+      val = deepMap(obj[k], cb);
+    } else {
+      val = cb(obj[k], k);
     }
-    // Merge in the default permissions, ensuring all values are set
-    // Note that the 'right' object being merged overrides any values set
-    // by the 'left' object.
-    return _.extend(sails.config.permissions, permissions);
-  },
-  deepMap = function(obj, cb) {
-    let out = {};
-    Object.keys(obj).forEach(function(k) {
-      let val;
-      if (obj[k] !== null && typeof obj[k] === 'object') {
-        val = deepMap(obj[k], cb);
-      } else {
-        val = cb(obj[k], k);
-      }
-      out[k] = val;
-    });
-    return out;
-  };
+    out[k] = val;
+  });
+  return out;
+};
 module.exports = {
   attributes: {
     username: {
@@ -73,7 +73,7 @@ module.exports = {
       for (var i = 0; i < models.length; i++) {
         for (var j = 0; j < roles.length; j++) {
           if (roles[j].isAdmin) {
-            roles[j].permissions = deepMap(sails.config.permissions, function(v, k) {
+            roles[j].permissions = deepMap(sails.config.permissions, (v, k) => {
               return true;
             });
           } else {

--- a/api/policies/isLoggedIn.js
+++ b/api/policies/isLoggedIn.js
@@ -1,5 +1,5 @@
-const passport = require('passport'),
-  crypto = require('crypto');
+const passport = require('passport');
+const crypto = require('crypto');
 
 module.exports = async (req, res, next) => {
   // 1) Opaque per-user API token: `Authorization: Bearer fpat_<token>`.
@@ -7,11 +7,11 @@ module.exports = async (req, res, next) => {
   //    login JWT. We store only the SHA-256, so hash the presented token and
   //    look the user up by it. Tag the request so credential writes (password,
   //    token) can be refused for API clients (see general/create|update|save).
-  let authHeader = req.headers && req.headers.authorization,
-    m = authHeader && /^Bearer\s+(fpat_[A-Za-z0-9]+)$/.exec(authHeader);
+  let authHeader = req.headers && req.headers.authorization;
+  let m = authHeader && /^Bearer\s+(fpat_[A-Za-z0-9]+)$/.exec(authHeader);
   if (m) {
-    let hash = crypto.createHash('sha256').update(m[1]).digest('hex'),
-      user = await User.findOne({ apiTokenHash: hash }).populateAll();
+    let hash = crypto.createHash('sha256').update(m[1]).digest('hex');
+    let user = await User.findOne({ apiTokenHash: hash }).populateAll();
     if (user) {
       req.authVia = 'apitoken';
       return req.login(user.toJSON(), { session: false }, (err) => err ? next(err) : next());

--- a/assets/fog/fog.assoc.js
+++ b/assets/fog/fog.assoc.js
@@ -21,7 +21,7 @@
     return Array.prototype.slice.call(picker.querySelectorAll('.assoc-row'));
   }
   function visibleRows(picker) {
-    return rows(picker).filter(function (r) { return !r.classList.contains('assoc-hidden'); });
+    return rows(picker).filter((r) => { return !r.classList.contains('assoc-hidden'); });
   }
   function rowBox(r) {
     return r.querySelector('td.assoc-check input[type="checkbox"]');
@@ -30,9 +30,11 @@
   // Recompute row highlight, the count, and the select-all (checked /
   // indeterminate) state for a single picker.
   function refresh(picker) {
-    var all = rows(picker), selected = 0;
-    all.forEach(function (r) {
-      var cb = rowBox(r), on = !!(cb && cb.checked);
+    var all = rows(picker);
+    var selected = 0;
+    all.forEach((r) => {
+      var cb = rowBox(r);
+      var on = !!(cb && cb.checked);
       r.classList.toggle('selected', on);
       if (on) { selected++; }
     });
@@ -46,7 +48,7 @@
     if (master) {
       // Base the master state on the rows the user can currently see.
       var vis = visibleRows(picker);
-      var visOn = vis.filter(function (r) { var c = rowBox(r); return c && c.checked; }).length;
+      var visOn = vis.filter((r) => { var c = rowBox(r); return c && c.checked; }).length;
       master.checked = vis.length > 0 && visOn === vis.length;
       master.indeterminate = visOn > 0 && visOn < vis.length;
     }
@@ -58,26 +60,26 @@
   }
 
   // Checkbox changes: select-all toggles the visible rows; any change refreshes.
-  document.addEventListener('change', function (e) {
+  document.addEventListener('change', (e) => {
     var t = e.target;
     if (!t || t.type !== 'checkbox') { return; }
     var picker = t.closest && t.closest('[data-assoc-picker]');
     if (!picker) { return; }
     if (t.hasAttribute('data-assoc-all')) {
       var on = t.checked;
-      visibleRows(picker).forEach(function (r) { var c = rowBox(r); if (c) { c.checked = on; } });
+      visibleRows(picker).forEach((r) => { var c = rowBox(r); if (c) { c.checked = on; } });
     }
     refresh(picker);
   });
 
   // Filter: hide non-matching rows by their label text.
-  document.addEventListener('input', function (e) {
+  document.addEventListener('input', (e) => {
     var t = e.target;
     if (!t || !t.hasAttribute || !t.hasAttribute('data-assoc-search')) { return; }
     var picker = t.closest && t.closest('[data-assoc-picker]');
     if (!picker) { return; }
     var q = t.value.trim().toLowerCase();
-    rows(picker).forEach(function (r) {
+    rows(picker).forEach((r) => {
       var name = (r.querySelector('.assoc-name') || {}).textContent || '';
       r.classList.toggle('assoc-hidden', !!q && name.toLowerCase().indexOf(q) === -1);
     });
@@ -89,7 +91,7 @@
   else { document.addEventListener('DOMContentLoaded', ready); }
 
   // The create/edit modal injects a server-rendered form once shown.
-  document.addEventListener('shown.bs.modal', function (e) { refreshAll(e.target); });
+  document.addEventListener('shown.bs.modal', (e) => { refreshAll(e.target); });
 
   // Let code that injects its own pickers re-sync them.
   window.fogInitAssoc = refreshAll;

--- a/assets/fog/fog.common.js
+++ b/assets/fog/fog.common.js
@@ -60,7 +60,7 @@ $.fn.registerTable = function(onSelect, opts) {
             body: 'This cannot be undone.',
             confirmText: 'Delete',
             danger: true
-          }).then(function(ok) {
+          }).then((ok) => {
             if (!ok) { return; }
             let base = dt.ajax.url().replace(/\/datatable.*$/, '');
             $.ajax({
@@ -100,7 +100,8 @@ $.fn.registerTable = function(onSelect, opts) {
   // create route simply omit it. 'page' navigates to /{plural}/create; 'modal'
   // lazy-loads that same server-rendered form into the shared #entityModal.
   if (opts.createMode === 'modal' || opts.createMode === 'page') {
-    let createMode = opts.createMode, createLabel = opts.createLabel;
+    let createMode = opts.createMode;
+    let createLabel = opts.createLabel;
     opts.buttons = [{
       text: '<i class="fa fa-plus"></i> ' + (createLabel || 'Create New'),
       className: 'btn-success',
@@ -124,7 +125,7 @@ $.fn.registerTable = function(onSelect, opts) {
   let table = $(this).DataTable(opts);
 
   if (onSelect !== undefined && typeof onSelect === 'function') {
-    table.on('select deselect', function(e, dt, type, indexes) {
+    table.on('select deselect', (e, dt, type, indexes) => {
       onSelect(dt.rows({selected: true}));
     });
   }
@@ -164,9 +165,9 @@ $.readableBytes = function(bytes) {
   window.fogCreateModal = function(url, dt) {
     let modalEl = document.getElementById('entityModal');
     if (!modalEl || !window.bootstrap) { window.location = url; return; }
-    let body = modalEl.querySelector('.modal-body'),
-      titleEl = modalEl.querySelector('.modal-title'),
-      modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+    let body = modalEl.querySelector('.modal-body');
+    let titleEl = modalEl.querySelector('.modal-title');
+    let modal = bootstrap.Modal.getOrCreateInstance(modalEl);
 
     body.innerHTML = '<div class="text-center p-4"><i class="fa fa-spinner fa-spin"></i> Loading…</div>';
     modal.show();
@@ -175,19 +176,19 @@ $.readableBytes = function(bytes) {
     // create round-trip can leave the modal open. Track the shown state and
     // defer the close until the modal has actually finished opening.
     let shown = false;
-    modalEl.addEventListener('shown.bs.modal', function() { shown = true; }, { once: true });
+    modalEl.addEventListener('shown.bs.modal', () => { shown = true; }, { once: true });
     function safeHide() {
       if (shown) { modal.hide(); }
-      else { modalEl.addEventListener('shown.bs.modal', function() { modal.hide(); }, { once: true }); }
+      else { modalEl.addEventListener('shown.bs.modal', () => { modal.hide(); }, { once: true }); }
     }
 
     fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' }, credentials: 'same-origin' })
-      .then(function(r) { return r.text(); })
-      .then(function(html) {
-        let doc = new DOMParser().parseFromString(html, 'text/html'),
-          // Scope to the page content so we never grab a navbar/search <form>.
-          form = doc.querySelector('.app-content form') || doc.querySelector('form'),
-          hdr = doc.querySelector('.app-content-header h3, .card-title');
+      .then((r) => { return r.text(); })
+      .then((html) => {
+        let doc = new DOMParser().parseFromString(html, 'text/html');
+        // Scope to the page content so we never grab a navbar/search <form>.
+        let form = doc.querySelector('.app-content form') || doc.querySelector('form');
+        let hdr = doc.querySelector('.app-content-header h3, .card-title');
         if (titleEl) { titleEl.textContent = hdr ? hdr.textContent.trim() : 'Create'; }
         if (!form) { showError(body, 'Could not load the form.'); return; }
         body.innerHTML = '';
@@ -197,10 +198,10 @@ $.readableBytes = function(bytes) {
         let cancel = form.querySelector('.btn-warning');
         if (cancel) {
           cancel.setAttribute('type', 'button');
-          cancel.addEventListener('click', function() { modal.hide(); });
+          cancel.addEventListener('click', () => { modal.hide(); });
         }
 
-        form.addEventListener('submit', function(ev) {
+        form.addEventListener('submit', (ev) => {
           ev.preventDefault();
           clearError(body);
           let payload = new URLSearchParams(new FormData(form)).toString();
@@ -213,11 +214,11 @@ $.readableBytes = function(bytes) {
               'Content-Type': 'application/x-www-form-urlencoded'
             },
             body: payload
-          }).then(function(r) {
-            return r.json().catch(function() { return {}; }).then(function(j) {
+          }).then((r) => {
+            return r.json().catch(() => { return {}; }).then((j) => {
               return { ok: r.ok, body: j };
             });
-          }).then(function(res) {
+          }).then((res) => {
             if (res.ok && res.body && res.body.ok) {
               safeHide();
               if (dt) { dt.ajax.reload(null, false); }
@@ -225,10 +226,10 @@ $.readableBytes = function(bytes) {
             } else {
               showError(body, (res.body && res.body.message) || 'Could not save. Please check your input.');
             }
-          }).catch(function() { showError(body, 'Network error — please try again.'); });
+          }).catch(() => { showError(body, 'Network error — please try again.'); });
         });
       })
-      .catch(function() { showError(body, 'Could not load the form.'); });
+      .catch(() => { showError(body, 'Could not load the form.'); });
   };
 })();
 
@@ -275,13 +276,13 @@ $.readableBytes = function(bytes) {
     else if (opts.body instanceof Node) { bodyEl.appendChild(opts.body); }
     document.body.appendChild(wrap);
     let m = bootstrap.Modal.getOrCreateInstance(wrap);
-    wrap.addEventListener('hidden.bs.modal', function() { m.dispose(); wrap.remove(); });
-    wrap.querySelector('[data-fog-confirm]').addEventListener('click', function() {
+    wrap.addEventListener('hidden.bs.modal', () => { m.dispose(); wrap.remove(); });
+    wrap.querySelector('[data-fog-confirm]').addEventListener('click', () => {
       let r = opts.onConfirm ? opts.onConfirm(wrap, m) : true;
-      Promise.resolve(r).then(function(keep) { if (keep !== false) { m.hide(); } });
+      Promise.resolve(r).then((keep) => { if (keep !== false) { m.hide(); } });
     });
     if (opts.onShown) {
-      wrap.addEventListener('shown.bs.modal', function() { opts.onShown(wrap); }, { once: true });
+      wrap.addEventListener('shown.bs.modal', () => { opts.onShown(wrap); }, { once: true });
     }
     m.show();
     return { el: wrap, modal: m, body: bodyEl };
@@ -290,21 +291,21 @@ $.readableBytes = function(bytes) {
   // Confirm dialog -> Promise<boolean>. Falls back to window.confirm().
   function confirm(opts) {
     opts = opts || {};
-    return new Promise(function(resolve) {
+    return new Promise((resolve) => {
       if (!window.bootstrap) {
         resolve(window.confirm(opts.body || opts.title || 'Are you sure?'));
         return;
       }
-      let answered = false,
-        ctrl = modal({
-          title: opts.title || 'Please confirm',
-          body: '<p class="mb-0">' + (opts.body || '') + '</p>',
-          confirmText: opts.confirmText || 'Confirm',
-          cancelText: opts.cancelText || 'Cancel',
-          danger: opts.danger,
-          onConfirm: function() { answered = true; resolve(true); }
-        });
-      ctrl.el.addEventListener('hidden.bs.modal', function() { if (!answered) { resolve(false); } });
+      let answered = false;
+      let ctrl = modal({
+        title: opts.title || 'Please confirm',
+        body: '<p class="mb-0">' + (opts.body || '') + '</p>',
+        confirmText: opts.confirmText || 'Confirm',
+        cancelText: opts.cancelText || 'Cancel',
+        danger: opts.danger,
+        onConfirm: function() { answered = true; resolve(true); }
+      });
+      ctrl.el.addEventListener('hidden.bs.modal', () => { if (!answered) { resolve(false); } });
     });
   }
 

--- a/assets/fog/fog.csrf.js
+++ b/assets/fog/fog.csrf.js
@@ -17,7 +17,7 @@
 
   // Inject _csrf into a mutating form just before it submits (capture phase, so
   // it runs before the create/edit modal reads the form's FormData).
-  document.addEventListener('submit', function (e) {
+  document.addEventListener('submit', (e) => {
     var f = e.target;
     if (!f || !f.tagName || f.tagName.toLowerCase() !== 'form') { return; }
     if (f.method && f.method.toLowerCase() === 'get') { return; }
@@ -70,8 +70,8 @@
     apply(local);
   } else if (window.fetch) {
     window.fetch('/csrfToken', { credentials: 'same-origin' })
-      .then(function (r) { return r.json(); })
-      .then(function (j) { apply(j && j._csrf); })
-      .catch(function () {});
+      .then((r) => { return r.json(); })
+      .then((j) => { apply(j && j._csrf); })
+      .catch(() => {});
   }
 })();

--- a/assets/fog/fog.maclist.js
+++ b/assets/fog/fog.maclist.js
@@ -19,9 +19,9 @@
   });
 
   $(document).on('click', '.maclist-remove', function() {
-    let $list = $(this).closest('[data-maclist]'),
-      $row = $(this).closest('.maclist-row'),
-      wasPrimary = $row.find('input[name="__primac"]').is(':checked');
+    let $list = $(this).closest('[data-maclist]');
+    let $row = $(this).closest('.maclist-row');
+    let wasPrimary = $row.find('input[name="__primac"]').is(':checked');
     $row.remove();
     // Keep a primary selected.
     if (wasPrimary && !$list.find('input[name="__primac"]:checked').length) {

--- a/assets/fog/fog.search.js
+++ b/assets/fog/fog.search.js
@@ -4,8 +4,8 @@
   if (!$input.length) {
     return;
   }
-  let $results = $('#globalSearchResults'),
-    timer = null;
+  let $results = $('#globalSearchResults');
+  let timer = null;
 
   function esc(s) {
     return $('<div>').text(s == null ? '' : s).html();
@@ -17,16 +17,16 @@
       return;
     }
     let html = '';
-    groups.forEach(function(g) {
+    groups.forEach((g) => {
       html += `<div class="px-2 py-1 small fw-bold text-muted bg-light">${esc(g.label)}</div>`;
-      g.items.forEach(function(it) {
+      g.items.forEach((it) => {
         html += `<a class="d-block px-2 py-1 text-decoration-none text-dark border-bottom text-truncate" href="/${g.plural}/edit/${it.id}">${esc(it.name)}</a>`;
       });
     });
     $results.html(html).show();
   }
 
-  $input.on('input', function() {
+  $input.on('input', () => {
     let q = $.trim($input.val());
     if (timer) {
       clearTimeout(timer);
@@ -35,20 +35,20 @@
       $results.hide().empty();
       return;
     }
-    timer = setTimeout(function() {
+    timer = setTimeout(() => {
       $.ajax({ url: '/api/v1/search', data: { q: q }, dataType: 'json' })
         .done(render)
-        .fail(function() { $results.hide(); });
+        .fail(() => { $results.hide(); });
     }, 250);
   });
 
-  $input.on('focus', function() {
+  $input.on('focus', () => {
     if ($results.children().length) {
       $results.show();
     }
   });
 
-  $(document).on('click', function(e) {
+  $(document).on('click', (e) => {
     if (!$(e.target).closest('#globalSearchWrap').length) {
       $results.hide();
     }

--- a/assets/fog/fog.select2.js
+++ b/assets/fog/fog.select2.js
@@ -32,16 +32,16 @@
   }
 
   // Initial page load (covers full-page forms and any selects already present).
-  $(function() { initSelect2(document); });
+  $(() => { initSelect2(document); });
 
   // The shared entity create/edit modal lazy-loads a server-rendered form;
   // enhance its selects once the modal has finished opening.
-  $(document).on('shown.bs.modal', function(e) {
+  $(document).on('shown.bs.modal', (e) => {
     initSelect2(e.target, $(e.target));
   });
 
   // DataTables builds its length <select> after the table initializes.
-  $(document).on('init.dt', function(e, settings) {
+  $(document).on('init.dt', (e, settings) => {
     initSelect2(settings.nTableWrapper || document);
   });
 

--- a/assets/fog/fog.taginput.js
+++ b/assets/fog/fog.taginput.js
@@ -38,8 +38,8 @@
   // Turn a bare `[data-taginput]` container into the chips + entry + hidden field.
   function build($root) {
     if ($root.data('taginputReady')) { return; }
-    let name = $root.attr('data-name') || 'tags',
-      tags = ($root.attr('data-tags') || '').split(/[\n,]+/).map((t) => $.trim(t)).filter(Boolean);
+    let name = $root.attr('data-name') || 'tags';
+    let tags = ($root.attr('data-tags') || '').split(/[\n,]+/).map((t) => $.trim(t)).filter(Boolean);
     $root.addClass('form-control fog-taginput').html(
       tags.map(chipHtml).join('') +
       '<input type="text" class="fog-taginput-entry" autocomplete="off" placeholder="add tag…">' +
@@ -57,7 +57,8 @@
   });
   // Enter or comma commits the entry; Backspace on an empty entry pops the last chip.
   $(document).on('keydown', '.fog-taginput-entry', function(e) {
-    let $entry = $(this), $root = $entry.closest('[data-taginput]');
+    let $entry = $(this);
+    let $root = $entry.closest('[data-taginput]');
     if (e.key === 'Enter' || e.key === ',') {
       e.preventDefault();
       addTag($root, $entry.val());
@@ -81,7 +82,7 @@
   function init(root) {
     $(root || document).find('[data-taginput]').each(function() { build($(this)); });
   }
-  $(function() { init(document); });
+  $(() => { init(document); });
 
   window.fogTagInput = {
     init: init,

--- a/config/passport/jwt.js
+++ b/config/passport/jwt.js
@@ -1,12 +1,12 @@
-const passport = require('passport'),
-  JWTStrategy = require('passport-jwt-cookiecombo'),
-  jwt = require('jsonwebtoken'),
-  locals = require('../../config/local'),
-  opts = {
-    secretOrPublicKey: locals.auth.jwt.secret,
-    jwtVerifyOptions: locals.auth.jwt.options,
-    session: locals.auth.jwt.session
-  };
+const passport = require('passport');
+const JWTStrategy = require('passport-jwt-cookiecombo');
+const jwt = require('jsonwebtoken');
+const locals = require('../../config/local');
+const opts = {
+  secretOrPublicKey: locals.auth.jwt.secret,
+  jwtVerifyOptions: locals.auth.jwt.options,
+  session: locals.auth.jwt.session
+};
 passport.serializeUser(async (user, done) => {
   done(null, user.id);
 });

--- a/config/passport/local.js
+++ b/config/passport/local.js
@@ -1,6 +1,6 @@
-const passport = require('passport'),
-  LocalStrategy = require('passport-local').Strategy,
-  bcrypt = require('bcryptjs');
+const passport = require('passport');
+const LocalStrategy = require('passport-local').Strategy;
+const bcrypt = require('bcryptjs');
 passport.serializeUser(async (user, done) => {
   done(null, user.id);
 });
@@ -13,7 +13,7 @@ passport.deserializeUser(async (id, done) => {
   });
 });
 passport.use(new LocalStrategy(
-  async function(username, password, done) {
+  async (username, password, done) => {
     await User.findOne({
       where: {
         or: [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,7 +35,13 @@ const rules = {
   'callback-return':              ['error', ['done', 'proceed', 'next', 'onwards', 'callback', 'cb']],
   'camelcase':                    ['warn', {'properties':'always'}],
   'comma-style':                  ['warn', 'last'],
-  'curly':                        ['warn'],
+  // 'multi-line' rather than the template's default 'all'.  Every one of the
+  // 125 hits the stricter setting produced was a single-line guard clause
+  // (`if (!user) return exits.forbidden();`), a style this codebase uses
+  // consistently and deliberately.  'multi-line' still requires braces the
+  // moment a body wraps onto its own line, which is the case that actually
+  // causes bugs.
+  'curly':                        ['warn', 'multi-line'],
   'eqeqeq':                       ['error', 'always'],
   'eol-last':                     ['warn'],
   'handle-callback-err':          ['error'],
@@ -68,7 +74,10 @@ const rules = {
   'no-use-before-define':         ['error', {'functions':false}],
   'one-var':                      ['warn', 'never'],
   'prefer-arrow-callback':        ['warn', {'allowNamedFunctions':true}],
-  'quotes':                       ['warn', 'single', {'avoidEscape':false, 'allowTemplateLiterals':true}],
+  // avoidEscape lets a double-quoted string stand when it contains single
+  // quotes.  With the template's `false`, the autofix turned readable DataTables
+  // `dom` strings into escape soup ('<\'row\'<\'col-sm-12\'f>>...').
+  'quotes':                       ['warn', 'single', {'avoidEscape':true, 'allowTemplateLiterals':true}],
   'semi':                         ['warn', 'always'],
   'semi-spacing':                 ['warn', {'before':false, 'after':true}],
   'semi-style':                   ['warn', 'last']

--- a/plugins/printer/index.js
+++ b/plugins/printer/index.js
@@ -9,8 +9,8 @@
  */
 const path = require('path');
 
-const LINK = 'plugin_printer_host',     // { host, printer }
-  CFG = 'plugin_printer_hostcfg';       // { host, level, defaultPrinter }
+const LINK = 'plugin_printer_host';     // { host, printer }
+const CFG = 'plugin_printer_hostcfg';       // { host, level, defaultPrinter }
 function linkColl() { return sails.getDatastore(sails.models.host.datastore).manager.collection(LINK); }
 function cfgColl() { return sails.getDatastore(sails.models.host.datastore).manager.collection(CFG); }
 function can(req, action) {
@@ -107,8 +107,10 @@ module.exports = {
   extends: {
     host: {
       form: async function (record) {
-        let printers = await sails.models.printer.find().sort('name ASC'),
-          checked = [], level = '0', def = '';
+        let printers = await sails.models.printer.find().sort('name ASC');
+        let checked = [];
+        let level = '0';
+        let def = '';
         if (record && record.id) {
           let links = await linkColl().find({ host: String(record.id) }).toArray();
           checked = links.map((l) => String(l.printer));

--- a/plugins/snapin/index.js
+++ b/plugins/snapin/index.js
@@ -122,8 +122,8 @@ module.exports = {
   extends: {
     host: {
       form: async function (record) {
-        let snapins = await sails.models.snapin.find().sort('name ASC'),
-          checked = [];
+        let snapins = await sails.models.snapin.find().sort('name ASC');
+        let checked = [];
         if (record && record.id) {
           let links = await linkColl().find({ host: String(record.id) }).toArray();
           checked = links.map((l) => String(l.snapin));

--- a/plugins/wol/index.js
+++ b/plugins/wol/index.js
@@ -11,11 +11,11 @@ function sendMagicPacket(mac) {
   return new Promise((resolve, reject) => {
     let hex = String(mac).replace(/[^0-9a-fA-F]/g, '');
     if (hex.length !== 12) { return reject(new Error(`Invalid MAC: ${mac}`)); }
-    let macBuf = Buffer.from(hex, 'hex'),
-      parts = [Buffer.alloc(6, 0xff)];
+    let macBuf = Buffer.from(hex, 'hex');
+    let parts = [Buffer.alloc(6, 0xff)];
     for (let i = 0; i < 16; i++) { parts.push(macBuf); }
-    let packet = Buffer.concat(parts), // 6 + 16*6 = 102 bytes
-      socket = dgram.createSocket('udp4');
+    let packet = Buffer.concat(parts); // 6 + 16*6 = 102 bytes
+    let socket = dgram.createSocket('udp4');
     socket.once('error', (err) => { socket.close(); reject(err); });
     socket.bind(() => {
       socket.setBroadcast(true);
@@ -35,8 +35,9 @@ module.exports = {
       if (!req.user) { return res.forbidden(); }
       let host = await sails.models.host.findOne({ id: req.param('id') });
       if (!host) { return res.notFound(); }
-      let macs = Array.isArray(host.macs) ? host.macs : (host.macs ? [host.macs] : []),
-        sent = [], failed = [];
+      let macs = Array.isArray(host.macs) ? host.macs : (host.macs ? [host.macs] : []);
+      let sent = [];
+      let failed = [];
       for (let mac of macs) {
         try { await sendMagicPacket(mac); sent.push(mac); } catch (err) { failed.push(mac); }
       }

--- a/tools/lib/config.js
+++ b/tools/lib/config.js
@@ -1,21 +1,21 @@
-const _ = require('@sailshq/lodash'),
-  path = require('path'),
-  fs = require('fs'),
-  appPath = path.join(__dirname, '..', '..'),
-  pkgPath = path.join(appPath, 'package.json'),
-  cfgPath = path.join(appPath, 'config'),
-  localCfg = path.join(cfgPath, 'local.js'),
-  safeReadJSON = function(filepath) {
-    if (!fs.existsSync(filepath)) return {};
-    let raw;
-    try {
-      raw = fs.readFileSync(filepath, 'utf8');
-    } catch (err) {
-      console.log(err);
-      return {};
-    }
-    return JSON.parse(raw) || {};
-  };
+const _ = require('@sailshq/lodash');
+const path = require('path');
+const fs = require('fs');
+const appPath = path.join(__dirname, '..', '..');
+const pkgPath = path.join(appPath, 'package.json');
+const cfgPath = path.join(appPath, 'config');
+const localCfg = path.join(cfgPath, 'local.js');
+const safeReadJSON = function(filepath) {
+  if (!fs.existsSync(filepath)) return {};
+  let raw;
+  try {
+    raw = fs.readFileSync(filepath, 'utf8');
+  } catch (err) {
+    console.log(err);
+    return {};
+  }
+  return JSON.parse(raw) || {};
+};
 
 module.exports = {
   appPath: appPath,
@@ -24,4 +24,4 @@ module.exports = {
     let preferences = require(localCfg);
     return _.merge(preferences, module.exports.package);
   },
-}
+};

--- a/tools/lib/header.js
+++ b/tools/lib/header.js
@@ -1,6 +1,6 @@
-const figlet = require('figlet'),
-  chalk = require('chalk'),
-  config = require('./config');
+const figlet = require('figlet');
+const chalk = require('chalk');
+const config = require('./config');
 
 module.exports = {
   print: (message) => {

--- a/tools/migrate/index.js
+++ b/tools/migrate/index.js
@@ -1,14 +1,14 @@
-const async = require('async'),
-  chalk = require('chalk'),
-  CLI = require('clui'),
-  Spinner = CLI.Spinner,
-  config = require('../lib/config'),
-  header = require('../lib/header'),
-  inquire = require('./lib/inquire'),
-  migrations = require('./lib/migration'),
-  welcome = 'Welcome to the FOG Schema Migrator.\nYou will be guided through migrating your current database schema';
-var COMPLETED = false,
-  revision = 0;
+const async = require('async');
+const chalk = require('chalk');
+const CLI = require('clui');
+const Spinner = CLI.Spinner;
+const config = require('../lib/config');
+const header = require('../lib/header');
+const inquire = require('./lib/inquire');
+const migrations = require('./lib/migration');
+const welcome = 'Welcome to the FOG Schema Migrator.\nYou will be guided through migrating your current database schema';
+var COMPLETED = false;
+var revision = 0;
 
 header.print(welcome);
 async.waterfall([
@@ -23,9 +23,9 @@ async.waterfall([
   // Perform Migration
   (next) => {
     header.printSection('Database Migration');
-    let status = new Spinner('Calculating deltas...'),
-      pendingText = 'Deltas calculated',
-      didMigrate = false;
+    let status = new Spinner('Calculating deltas...');
+    let pendingText = 'Deltas calculated';
+    let didMigrate = false;
     status.start();
     migrations.auto(config.preferences.datastores.fogdb, (upgrade, fromRev, toRev, description) => {
       didMigrate = true;
@@ -37,7 +37,7 @@ async.waterfall([
       status = new Spinner(pendingText);
       status.start();
     }, (err) => {
-      status.stop()
+      status.stop();
       console.log(pendingText);
       if (err) return next(err);
       if (didMigrate) {

--- a/tools/migrate/lib/migration.js
+++ b/tools/migrate/lib/migration.js
@@ -1,15 +1,15 @@
-const fs = require('fs'),
-  path = require('path'),
-  migrationsFolder = path.join(__dirname, '..', '..', '..', 'migrations'),
-  config = require('../../lib/config'),
-  database = require('../../lib/database'),
-  setting = require('../../lib/setting');
+const fs = require('fs');
+const path = require('path');
+const migrationsFolder = path.join(__dirname, '..', '..', '..', 'migrations');
+const config = require('../../lib/config');
+const database = require('../../lib/database');
+const setting = require('../../lib/setting');
 module.exports = {
   getMigrations: (start, end) => {
     if (start == end) return [];
     if (start < end && start == end+1) return [];
-    let revisions = [],
-      toLoad = [];
+    let revisions = [];
+    let toLoad = [];
     if (start < end) {
       for (var i = start + 1; i <= end; i++) {
         toLoad.push(i);
@@ -50,8 +50,8 @@ module.exports = {
       if (err) return next(err);
       module.exports.getCurrentRevision(db, (err, current) => {
         if (err) return next(err);
-        let upgrade = target > current,
-          revisions;
+        let upgrade = target > current;
+        let revisions;
         try {
           revisions = module.exports.getMigrations(current, target);
         } catch (e) {

--- a/tools/setup/dev.js
+++ b/tools/setup/dev.js
@@ -24,26 +24,26 @@
  * This is for LOCAL DEVELOPMENT ONLY. For a real install use
  * `node tools/setup/index.js`.
  */
-const fs = require('fs'),
-  path = require('path'),
-  config = require('../lib/config'),
-  secure = require('./lib/secure'),
-  schema = require('./lib/schema'),
-  cfgPath = path.join(config.appPath, 'config'),
-  localCfg = path.join(cfgPath, 'local.js'),
-  modelsCfg = path.join(cfgPath, 'models.js'),
-  env = process.env,
-  db = {
-    host: env.FOG_DEV_DB_HOST || '127.0.0.1',
-    port: env.FOG_DEV_DB_PORT || '27017',
-    name: env.FOG_DEV_DB_NAME || 'fog',
-    user: env.FOG_DEV_DB_USER || '',
-    pass: env.FOG_DEV_DB_PASS || ''
-  },
-  admin = {
-    email: env.FOG_DEV_ADMIN_EMAIL || 'admin@example.com',
-    password: env.FOG_DEV_ADMIN_PASSWORD || 'fogadmin1'
-  };
+const fs = require('fs');
+const path = require('path');
+const config = require('../lib/config');
+const secure = require('./lib/secure');
+const schema = require('./lib/schema');
+const cfgPath = path.join(config.appPath, 'config');
+const localCfg = path.join(cfgPath, 'local.js');
+const modelsCfg = path.join(cfgPath, 'models.js');
+const env = process.env;
+const db = {
+  host: env.FOG_DEV_DB_HOST || '127.0.0.1',
+  port: env.FOG_DEV_DB_PORT || '27017',
+  name: env.FOG_DEV_DB_NAME || 'fog',
+  user: env.FOG_DEV_DB_USER || '',
+  pass: env.FOG_DEV_DB_PASS || ''
+};
+const admin = {
+  email: env.FOG_DEV_ADMIN_EMAIL || 'admin@example.com',
+  password: env.FOG_DEV_ADMIN_PASSWORD || 'fogadmin1'
+};
 
 function mongoUrl() {
   let auth = '';

--- a/tools/setup/index.js
+++ b/tools/setup/index.js
@@ -1,23 +1,23 @@
-const chalk = require('chalk'),
-  fs = require('fs'),
-  path = require('path'),
-  header = require('../lib/header'),
-  config = require('../lib/config'),
-  cfgPath = path.join(config.appPath, 'config'),
-  httpCfg = path.join(cfgPath, 'http.js'),
-  modelsCfg = path.join(cfgPath, 'models.js'),
-  localCfg = path.join(cfgPath, 'local.js'),
-  inquire = require('./lib/inquire'),
-  schema = require('./lib/schema'),
-  seedDemo = require('./seed-demo'),
-  secure = require('./lib/secure'),
-  async = require('async'),
-  CLI = require('clui'),
-  Spinner = CLI.Spinner,
-  welcome = `Welcome to the FOG installer.\nYou will be guided through configuring your new server for production.`;
+const chalk = require('chalk');
+const fs = require('fs');
+const path = require('path');
+const header = require('../lib/header');
+const config = require('../lib/config');
+const cfgPath = path.join(config.appPath, 'config');
+const httpCfg = path.join(cfgPath, 'http.js');
+const modelsCfg = path.join(cfgPath, 'models.js');
+const localCfg = path.join(cfgPath, 'local.js');
+const inquire = require('./lib/inquire');
+const schema = require('./lib/schema');
+const seedDemo = require('./seed-demo');
+const secure = require('./lib/secure');
+const async = require('async');
+const CLI = require('clui');
+const Spinner = CLI.Spinner;
+const welcome = `Welcome to the FOG installer.\nYou will be guided through configuring your new server for production.`;
 
-var COMPLETED = false,
-  payload = {};
+var COMPLETED = false;
+var payload = {};
 
 header.print(welcome);
 
@@ -70,7 +70,7 @@ async.waterfall([
     payload.auth.jwt.cookie = {
       signed: true,
       maxAge: 24 * 1000 * 60 * 60
-    }
+    };
     status.stop();
     console.log('JWT secret generated');
     next();

--- a/tools/setup/lib/inquire.js
+++ b/tools/setup/lib/inquire.js
@@ -1,23 +1,23 @@
-const inquirer = require('inquirer'),
-  CLI = require('clui'),
-  Spinner = CLI.Spinner,
-  chalk = require('chalk'),
-  database = require('../../lib/database'),
-  verifyDB = (answers, next) => {
-    let status = new Spinner('Verifying database information, please wait...');
-    status.start();
-    database.connect(answers.host, answers.port, answers.database, answers.username, answers.password, (err, db) => {
-      status.stop();
-      let prefix = 'MongoError: ';
-      if (err) {
-        err = err.toString().replace(prefix, '');
-        console.log(chalk.bgRed(`--> Incorrect database information: ${err}`));
-        return next(err);
-      }
-      console.log(chalk.green('Database information verified'));
-      next();
-    });
-  };
+const inquirer = require('inquirer');
+const CLI = require('clui');
+const Spinner = CLI.Spinner;
+const chalk = require('chalk');
+const database = require('../../lib/database');
+const verifyDB = (answers, next) => {
+  let status = new Spinner('Verifying database information, please wait...');
+  status.start();
+  database.connect(answers.host, answers.port, answers.database, answers.username, answers.password, (err, db) => {
+    status.stop();
+    let prefix = 'MongoError: ';
+    if (err) {
+      err = err.toString().replace(prefix, '');
+      console.log(chalk.bgRed(`--> Incorrect database information: ${err}`));
+      return next(err);
+    }
+    console.log(chalk.green('Database information verified'));
+    next();
+  });
+};
 
 module.exports = {
   getDatabaseInfo: (next) => {

--- a/tools/setup/lib/schema.js
+++ b/tools/setup/lib/schema.js
@@ -1,19 +1,19 @@
-const config = require('../../lib/config'),
-  sails = require('sails');
+const config = require('../../lib/config');
+const sails = require('sails');
 var adminRole = {
-    name: 'Administrator',
-    isAdmin: true,
-    permissions: {},
-  },
-  adminUser = {
-    username: 'Administrator',
-  },
-  schema = {
-    name: 'schema',
-    value: {
-      revision: 0
-    }
-  };
+  name: 'Administrator',
+  isAdmin: true,
+  permissions: {},
+};
+var adminUser = {
+  username: 'Administrator',
+};
+var schema = {
+  name: 'schema',
+  value: {
+    revision: 0
+  }
+};
 
 module.exports = {
   generate: (adminPassword, adminEmail, next) => {

--- a/tools/setup/lib/secure.js
+++ b/tools/setup/lib/secure.js
@@ -1,5 +1,5 @@
-const _ = require('@sailshq/lodash'),
-  crypto = require('crypto');
+const _ = require('@sailshq/lodash');
+const crypto = require('crypto');
 
 module.exports = {
   generateSecret: () => {
@@ -7,8 +7,8 @@ module.exports = {
       creationDate: (new Date()).getTime(),
       random: Math.random() * (Math.random() * 1000),
       nodeVersion: process.version
-    },
-      basestring = '';
+    };
+    let basestring = '';
 
     _.each(factors, (val) => {
       basestring += val;

--- a/tools/setup/seed-demo.js
+++ b/tools/setup/seed-demo.js
@@ -36,7 +36,8 @@ const pick = (a) => a[rint(a.length)];
 const chance = (p) => Math.random() < p;
 const pad = (n, w) => String(n).padStart(w, '0');
 function sampleK(arr, k) {
-  const c = arr.slice(), out = [];
+  const c = arr.slice();
+  const out = [];
   while (k-- > 0 && c.length) { out.push(c.splice(rint(c.length), 1)[0]); }
   return out;
 }
@@ -184,7 +185,8 @@ async function seedDemoData(opts) {
     const n = Math.min(batchSize, numHosts - batchStart);
     for (let j = 0; j < n; j++) {
       const idx = start + batchStart + j;
-      const dept = pick(DEPTS), type = pick(TYPES);
+      const dept = pick(DEPTS);
+      const type = pick(TYPES);
       const macs = [randomMac()];
       if (chance(0.18)) { macs.push(randomMac()); } // some dual-NIC hosts
       batch.push({

--- a/tools/setup/seed-dev.js
+++ b/tools/setup/seed-dev.js
@@ -15,8 +15,8 @@
  *   npm run seed:dev
  *   FOG_DEV_ADMIN_PASSWORD='supersecret' npm run seed:dev
  */
-const config = require('../lib/config'),
-  sails = require('sails');
+const config = require('../lib/config');
+const sails = require('sails');
 
 if (process.env.NODE_ENV === 'production') {
   console.error('Refusing to run the dev seed with NODE_ENV=production (it clears data).');

--- a/views/pages/partials/dashboard.js
+++ b/views/pages/partials/dashboard.js
@@ -1,18 +1,18 @@
 (function($) {
   // Percentage helper for doughnut tooltips (Chart.js v4).
   function pctLabel(context) {
-    let val = Number(context.parsed) || 0,
-      total = context.dataset.data.reduce((a, b) => a + Number(b), 0),
-      pct = total ? (val / total * 100).toFixed(1) : 0;
+    let val = Number(context.parsed) || 0;
+    let total = context.dataset.data.reduce((a, b) => a + Number(b), 0);
+    let pct = total ? (val / total * 100).toFixed(1) : 0;
     return ` ${context.label}: ${pct}%`;
   }
 
   // Activity Usage
-  let qavail = Number($('#avail').val()) || 0,
-    qactive = Number($('#active').val()) || 0,
-    qstaged = Number($('#staged').val()) || 0,
-    qtotal = qavail + qactive + qstaged,
-    activeUsageCanvas = $('#activityUsage').get(0);
+  let qavail = Number($('#avail').val()) || 0;
+  let qactive = Number($('#active').val()) || 0;
+  let qstaged = Number($('#staged').val()) || 0;
+  let qtotal = qavail + qactive + qstaged;
+  let activeUsageCanvas = $('#activityUsage').get(0);
   if (activeUsageCanvas) {
     // Empty state: a 0/0/0 doughnut renders blank, so when there's no capacity
     // and no tasks show a single neutral "No activity" ring instead of nothing.
@@ -40,14 +40,14 @@
   }
 
   // Disk Usage
-  let free = Number($('#free').val()) || 0,
-    used = Number($('#used').val()) || 0,
-    hFree = $.readableBytes(free),
-    hUsed = $.readableBytes(used),
-    total = free + used,
-    freePct = total ? (free / total * 100).toFixed(1) : 0,
-    usedPct = total ? (used / total * 100).toFixed(1) : 0,
-    diskUsageCanvas = $('#diskUsage').get(0);
+  let free = Number($('#free').val()) || 0;
+  let used = Number($('#used').val()) || 0;
+  let hFree = $.readableBytes(free);
+  let hUsed = $.readableBytes(used);
+  let total = free + used;
+  let freePct = total ? (free / total * 100).toFixed(1) : 0;
+  let usedPct = total ? (used / total * 100).toFixed(1) : 0;
+  let diskUsageCanvas = $('#diskUsage').get(0);
   if (diskUsageCanvas) {
     new Chart(diskUsageCanvas.getContext('2d'), {
       type: 'doughnut',
@@ -73,8 +73,8 @@
   }
 
   // Task History (category x-axis -> no time adapter needed)
-  let taskHistoryChart,
-    taskHistoryTimeout;
+  let taskHistoryChart;
+  let taskHistoryTimeout;
 
   function historyCanvas(taskChartData) {
     let history = $('#taskHistory').get(0);
@@ -138,12 +138,12 @@
   // the history we already collected instead of starting over from the smaller
   // window's oldest point. Purely client-side (matches the 1.x 2m/5m/10m/30m/1h).
   let BANDWIDTH_MAX_RETAIN_SEC = 3600;
-  let bandwidthChart,
-    bandwidthSamples = [],      // {t, label, rx, tx}; retained up to MAX_RETAIN
-    bandwidthIface = '',
-    bandwidthWindowSec = 120,   // selected DISPLAY window (default: 2 minutes)
-    bandwidthinterval,
-    bandwidthajax;
+  let bandwidthChart;
+  let bandwidthSamples = [];      // {t, label, rx, tx}; retained up to MAX_RETAIN
+  let bandwidthIface = '';
+  let bandwidthWindowSec = 120;   // selected DISPLAY window (default: 2 minutes)
+  let bandwidthinterval;
+  let bandwidthajax;
 
   function bandwidthCanvas(data) {
     let bandwidth = $('#bandwidth').get(0);
@@ -163,11 +163,11 @@
   // Show only the samples inside the selected window; the rest stay buffered for
   // when a longer window is picked. Creates the chart on first render.
   function renderBandwidth(now) {
-    let cutoff = now - bandwidthWindowSec * 1000,
-      view = bandwidthSamples.filter((s) => s.t >= cutoff),
-      labels = view.map((s) => s.label),
-      rx = view.map((s) => s.rx),
-      tx = view.map((s) => s.tx);
+    let cutoff = now - bandwidthWindowSec * 1000;
+    let view = bandwidthSamples.filter((s) => s.t >= cutoff);
+    let labels = view.map((s) => s.label);
+    let rx = view.map((s) => s.rx);
+    let tx = view.map((s) => s.tx);
     if (!bandwidthChart) {
       bandwidthCanvas({
         labels: labels,
@@ -195,9 +195,9 @@
           // rx_sec/tx_sec are bytes/sec -> Mbps (bits/sec / 1e6), kept to 2dp so
           // sub-Mbps idle traffic is visible instead of rounding to a flat 0.
           // (si's first sample can be -1; treat anything not > 0 as 0.)
-          let stat = series.netstats[0],
-            toMbps = function(bps) { return (typeof bps === 'number' && bps > 0) ? Math.round((bps * 8 / 1e6) * 100) / 100 : 0; },
-            now = Date.now();
+          let stat = series.netstats[0];
+          let toMbps = function(bps) { return (typeof bps === 'number' && bps > 0) ? Math.round((bps * 8 / 1e6) * 100) / 100 : 0; };
+          let now = Date.now();
           bandwidthIface = stat.iface;
           bandwidthSamples.push({ t: now, label: new Date(now).toLocaleTimeString(), rx: toMbps(stat.rx_sec), tx: toMbps(stat.tx_sec) });
           // Trim the buffer to the largest window so memory stays bounded.

--- a/views/pages/partials/list/host.js
+++ b/views/pages/partials/list/host.js
@@ -21,8 +21,8 @@
     if (ids.length) {
       return { body: {id: ids}, all: false, desc: `${ids.length} selected host(s)` };
     }
-    let n = dt.page.info().recordsDisplay,
-      search = dt.search() || '';
+    let n = dt.page.info().recordsDisplay;
+    let search = dt.search() || '';
     return {
       body: {all: true, search: search},
       all: true,
@@ -45,7 +45,7 @@
 
     function show(knownTags) {
       let removeHtml = knownTags.length
-        ? '<div class="fog-tag-remove-list">' + knownTags.map(function(t) {
+        ? '<div class="fog-tag-remove-list">' + knownTags.map((t) => {
           let v = escHtml(t);
           return '<div class="form-check form-check-inline">' +
             '<input class="form-check-input" type="checkbox" value="' + v + '">' +
@@ -66,8 +66,8 @@
         onShown: function(wrap) { if (window.fogTagInput) { window.fogTagInput.init(wrap); } },
         onConfirm: function(wrap) {
           let addTags = window.fogTagInput
-              ? window.fogTagInput.values(wrap.querySelector('[data-taginput]')) : [],
-            removeTags = $(wrap).find('.fog-tag-remove-list input:checked')
+              ? window.fogTagInput.values(wrap.querySelector('[data-taginput]')) : [];
+          let removeTags = $(wrap).find('.fog-tag-remove-list input:checked')
               .map(function() { return this.value; }).get();
           if (!addTags.length && !removeTags.length) {
             window.fogToast('error', 'Add or select at least one tag.');
@@ -81,28 +81,29 @@
     // Removable-tag source: the union across selected rows, or -- acting on all
     // matching -- every tag in the system.
     if (!target.all) {
-      let seen = {}, list = [];
-      dt.rows({selected: true}).data().toArray().forEach(function(r) {
-        (Array.isArray(r.tags) ? r.tags : []).forEach(function(t) {
+      let seen = {};
+      let list = [];
+      dt.rows({selected: true}).data().toArray().forEach((r) => {
+        (Array.isArray(r.tags) ? r.tags : []).forEach((t) => {
           let k = String(t).toLowerCase();
           if (!seen[k]) { seen[k] = true; list.push(t); }
         });
       });
-      list.sort(function(a, b) { return a.toLowerCase().localeCompare(b.toLowerCase()); });
+      list.sort((a, b) => { return a.toLowerCase().localeCompare(b.toLowerCase()); });
       show(list);
     } else {
       $.getJSON('/api/v1/host/tags')
-        .done(function(res) { show((res && res.tags) || []); })
-        .fail(function() { show([]); });
+        .done((res) => { show((res && res.tags) || []); })
+        .fail(() => { show([]); });
     }
   }
 
   // Bulk "Set image": pick from a dropdown (or clear) instead of typing a name.
   function openImageModal(dt) {
     let target = resolveTarget(dt);
-    $.getJSON('/api/v1/image').done(function(images) {
+    $.getJSON('/api/v1/image').done((images) => {
       let opts = '<option value="">(clear image)</option>' +
-        (images || []).map(function(im) {
+        (images || []).map((im) => {
           let v = escHtml(im.name);
           return '<option value="' + v + '">' + v + '</option>';
         }).join('');
@@ -117,7 +118,7 @@
           bulk(dt, $.extend({}, target.body, {image: name}));
         }
       });
-    }).fail(function() { window.fogToast('error', 'Could not load images.'); });
+    }).fail(() => { window.fogToast('error', 'Could not load images.'); });
   }
 
   $('#listtable').registerTable(undefined, {
@@ -171,7 +172,7 @@
         render: function(data) {
           let tags = Array.isArray(data) ? data : (data ? [data] : []);
           if (!tags.length) { return ''; }
-          return '<span class="fog-tag-list">' + tags.map(function(t) {
+          return '<span class="fog-tag-list">' + tags.map((t) => {
             return '<span class="badge bg-primary">' + escHtml(t) + '</span>';
           }).join('') + '</span>';
         }

--- a/views/pages/partials/list/image.js
+++ b/views/pages/partials/list/image.js
@@ -16,8 +16,8 @@
             url: '/api/v1/image/scan',
             type: 'POST',
             complete: function(xhr) {
-              let r = (xhr && xhr.responseJSON) || {},
-                n = (r.created || []).length;
+              let r = (xhr && xhr.responseJSON) || {};
+              let n = (r.created || []).length;
               if (r.error) {
                 window.fogToast('error', r.error);
               } else {


### PR DESCRIPTION
Follow-up to #89, which restored the linter but left 581 pre-existing findings. This takes them to **208**.

Two commits, deliberately separate — the first is a judgement call worth reviewing on its own, the second is mechanical.

## 1. `fix(lint): align curly and quotes with actual house style` — no code changed

**`curly: 'all'` → `'multi-line'`.** The strict setting produced 125 findings and *every single one* was a single-line guard clause:

```js
if (req.authVia === 'apitoken') return exits.forbidden();
```

125 out of 125 sites, no counter-examples — that's the established idiom here, not drift. `'multi-line'` reports **zero** findings against the code as written, while still requiring braces the moment a body wraps onto its own line (the case that actually causes bugs). Bracing all 125 instead would have churned ~60 files against a deliberate style, and ESLint's autofix emits them inline (`if (x) {return y;}`), so every one would have needed hand-reformatting afterwards.

**`quotes: avoidEscape` `false` → `true`.** With `false`, the autofix rewrote readable DataTables `dom` strings into escape soup:

```diff
- dom: "<'row'<'col-sm-12'f>>B<'row'<'col-sm-12'tr>>"
+ dom: '<\'row\'<\'col-sm-12\'f>>B<\'row\'<\'col-sm-12\'tr>>'
```

`avoidEscape` exists precisely to let a double-quoted string stand when it contains single quotes. Drops 3 findings to 1; the remaining one is genuine.

Net: **581 → 454 findings, zero code touched.** Both settings carry inline comments explaining why.

## 2. `chore(lint): apply ESLint autofix across the codebase` — 96 files

`eslint . --fix` for `one-var`, `prefer-arrow-callback`, `indent`, `semi`, `semi-spacing`, `no-trailing-spaces`, `no-extra-semi`, `comma-style`, `eol-last`, `quotes`. Autofixes for these rules are AST-preserving by construction.

**Hand-tidied afterwards:** the `one-var` autofix splits comma declarations but leaves them on the source line, so 16 sites came out as `let a = x; let b = y;`. I split those onto separate lines by hand. No `; let` / `; const` / `; var` sequences remain outside for-headers.

**454 → 208.**

## What's left (208) — all needs human judgement

| Rule | Count | |
|---|---|---|
| `no-unused-vars` | 99 | warn |
| `block-scoped-var` | 60 | **error** |
| `camelcase` | 20 | warn |
| `eqeqeq` | 10 | **error** |
| `no-redeclare` | 8 | warn |
| `handle-callback-err` | 4 | **error** |
| `no-sequences` | 4 | **error** |
| `callback-return` | 3 | **error** |

`eqeqeq` changes comparison semantics, `handle-callback-err` means deciding what to do with swallowed errors, and `block-scoped-var` needs `var`-hoisting restructures. None are safe to automate.

## Verification

- All 96 changed files parse (`node --check`)
- `grunt build` completes, including Babel transpilation of every changed asset
- `sails-linker` regenerates `views/layouts/layout.ejs` **byte-identical** to the committed copy, confirming the asset pipeline still agrees with the layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)