### PR TITLE
fix(test): unbreak the route suite and wire it into npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "supertest": "^7.2.2"
   },
   "comments": {
+    "custom-tests": "The mocha suite lifts a real Sails app. PORT=1338 keeps it off 1337 so the suite can run while a dev server is up. sails_hooks__grunt=false skips the asset pipeline: it is irrelevant to these route tests, and letting it run makes sails-linker rewrite the <script>/<link> block in views/layouts/layout.ejs from whatever happens to be in .tmp — on a fresh clone or CI checkout that directory is empty, so `npm test` would silently strip every vendor tag out of a tracked file. --recursive is required or test/route/ is skipped; --exit is required because Sails leaves handles open after lower().",
     "overrides": "Force-patch vulnerable transitive deps pinned by the abandoned sails-hook-grunt/grunt-contrib-less build chain. npm audit fix can't reach them because their parents are unmaintained. Keys of the form 'pkg@N' pin one major at a time, so each consumer keeps the major it was written against. 'less' is forced to 4.x: grunt-contrib-less@1.3.0 asks for less ~2.6.0, but less >=4.6 dropped its bundled HTTP importer, which is what dragged in the unpatchable 'request' and 'image-size' advisories — 'grunt less:dev' output was verified byte-identical before and after that bump. babel-traverse@6 is knowingly left vulnerable: it comes from babel-core@6 inside sails-hook-grunt, there is no 6.x patch, and dropping it would mean dropping asset transpilation from the prod build."
   },
   "overrides": {
@@ -102,7 +103,7 @@
     "seed:dev": "node tools/setup/seed-dev.js",
     "test": "npm run lint && npm run custom-tests && echo 'Done.'",
     "lint": "./node_modules/eslint/bin/eslint.js . --max-warnings=0 --report-unused-disable-directives && echo '✔  Your .js files look good.'",
-    "custom-tests": "echo \"(No other custom tests yet.)\" && echo"
+    "custom-tests": "PORT=1338 sails_hooks__grunt=false mocha --recursive --exit"
   },
   "main": "app.js",
   "repository": {

--- a/test/route/routes.test.js
+++ b/test/route/routes.test.js
@@ -1,9 +1,16 @@
 const supertest = require('supertest');
 describe('Route tests::', () =>  {
   var token = '';
+  // `X-Requested-With` marks the request as same-origin AJAX, which is what
+  // api/policies/apiCsrfGuard.js requires before it will let a session-
+  // authenticated request mutate anything. Real clients send it for free
+  // (jQuery sets it on every $.ajax; assets/fog/fog.common.js sets it on its
+  // fetch calls), but supertest does not, so without it every POST/PUT/DELETE
+  // below is refused with a 403.
   var hook = (method = 'get') =>
     (args) =>
-      supertest(sails.hooks.http.app)[method](args);
+      supertest(sails.hooks.http.app)[method](args)
+        .set('X-Requested-With', 'XMLHttpRequest');
   var request = {
     post: hook('post'),
     get: hook('get'),
@@ -59,7 +66,8 @@ describe('Route tests::', () =>  {
   hook = (method = 'get') =>
     (args) =>
       supertest(sails.hooks.http.app)[method](args)
-        .set('Authorization', token);
+        .set('Authorization', token)
+        .set('X-Requested-With', 'XMLHttpRequest');
   var request = {
     post: hook('post'),
     get: hook('get'),
@@ -87,7 +95,14 @@ describe('Route tests::', () =>  {
             password: 'testmochauser'
           })
           .expect(200, (err, info) => {
+            // Passing a callback to .expect() hands it the assertion error
+            // instead of throwing, so this has to be checked by hand -- it was
+            // previously dropped, which let a 403 here report as a pass and
+            // surface instead as two confusing 403s from the update/destroy
+            // tests below (they were requesting /api/v1/user/undefined).
+            if (err) return done(err);
             userid = info.body.id;
+            if (!userid) return done(new Error('Create returned no user id'));
             done();
           });
       });


### PR DESCRIPTION
The mocha suite has never run as part of `npm test` — `custom-tests` was still the Sails template's placeholder `echo` — and when run by hand it reported two failures. Both fixed.

## The failures were CSRF, not permissions

`api/policies/apiCsrfGuard.js` lets a session-authenticated request mutate state only if it carries `X-Requested-With: XMLHttpRequest` (same-origin AJAX, which a cross-origin attacker can't set without a preflight). Real clients send it for free — jQuery sets it on every `$.ajax`, and `assets/fog/fog.common.js` sets it explicitly on its fetch calls. supertest doesn't, so every POST/PUT/DELETE was refused with a 403.

The test now sets it, making it behave like the browser client it stands in for.

**No policy, role or permission was changed.** `Mocha_Test_Admin` has `isAdmin: true`, and `User.js` grants admin roles every permission — which is why the GETs always passed. I'd initially flagged this as an access-control fix; it isn't.

## Two failures were reported, but three requests were failing

The create test passed a callback to `.expect(200, cb)`, which hands it the assertion error rather than throwing — and the callback dropped `err`:

```js
.expect(200, (err, info) => {
  userid = info.body.id;     // err discarded; 403 reports as a pass
  done();
});
```

So its own 403 was reported as **passing**, `userid` was left `undefined`, and the update/destroy tests went on to request `/api/v1/user/undefined` — which is where the two *visible* 403s actually came from. The callback now checks `err` and asserts an id came back, so a failure reports at its source.

That also cleared a genuine `handle-callback-err` lint error (208 → 207 findings).

## Wiring

```
"custom-tests": "PORT=1338 sails_hooks__grunt=false mocha --recursive --exit"
```

| Flag | Why |
|---|---|
| `PORT=1338` | Keeps the lift off 1337 so the suite runs while a dev server is up |
| `sails_hooks__grunt=false` | Skips the asset pipeline — irrelevant to route tests, and letting it run makes `sails-linker` rewrite the `<script>`/`<link>` block in `views/layouts/layout.ejs` from whatever is in `.tmp`. On a fresh clone or CI checkout that's empty, so `npm test` would silently strip every vendor tag out of a tracked file. |
| `--recursive` | Required, or `test/route/` is never collected |
| `--exit` | Required — Sails leaves handles open after `lower()` |

Reasoning is recorded in `comments.custom-tests` in package.json, matching the existing `comments.overrides` convention.

## Verification

- **10 passing, 0 failing**, exit 0
- `layout.ejs` untouched by the run
- Suite leaves no records behind — it creates and destroys both fixtures (verified directly against Mongo)

## One caveat

`npm test` still fails overall, at the **lint** step, on the 207 pre-existing findings — `&&` short-circuits, so mocha isn't reached until those are dealt with. `npm run custom-tests` runs the suite on its own in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)