### PR TITLE
fix(lint): clear 20 lint errors, incl. two real bugs

### DIFF
--- a/api/controllers/auth/login.js
+++ b/api/controllers/auth/login.js
@@ -33,7 +33,7 @@ module.exports = {
           async (err, token) => {
             if (err) return exits.error(err);
             if (!token) return exits.error('Invalid token created');
-            if (req.param('remember-me') == 'on') res.cookie('jwt', token, sails.config.auth.jwt.cookie);
+            if (req.param('remember-me') === 'on') res.cookie('jwt', token, sails.config.auth.jwt.cookie);
             if (req.wantsJSON) return exits.success({token});
             return res.redirect('/');
           }

--- a/api/controllers/auth/token.js
+++ b/api/controllers/auth/token.js
@@ -13,6 +13,11 @@ module.exports = {
     let req = this.req;
     let res = this.res;
     await jwt.sign({user: req.user.id}, jwtConfig.secret, jwtConfig.options, async (err, token) => {
+      // Without these the endpoint answered 200 with `{token: undefined}`
+      // whenever signing failed, handing the caller a success it could not
+      // use. Mirrors the handling in auth/login.js, which signs the same way.
+      if (err) return exits.error(err);
+      if (!token) return exits.error('Invalid token created');
       return exits.success({token});
     });
   }

--- a/api/controllers/general/create.js
+++ b/api/controllers/general/create.js
@@ -23,7 +23,10 @@ module.exports = {
     // API-token requests may never write credentials (password / apiTokenHash).
     if (req.authVia === 'apitoken') { delete params.password; delete params.apiTokenHash; }
     let obj = await sails.models[model].create(params)
-      .intercept('E_UNIQUE', (err) => {
+      // The adapter error carries no detail worth surfacing here, so it is
+      // deliberately dropped in favour of a fixed message; named `unusedErr`
+      // to say so rather than leaving a silently-ignored `err`.
+      .intercept('E_UNIQUE', (unusedErr) => {
         return {conflict: {message: 'A record already exists with that name'}};
       })
       .intercept({name: 'UsageError'}, (err) => {

--- a/api/controllers/general/update.js
+++ b/api/controllers/general/update.js
@@ -26,7 +26,9 @@ module.exports = {
     let orig = [];
     let toRem = [];
     let obj = await sails.models[model].updateOne({id}, params)
-      .intercept('E_UNIQUE', (err) => {
+      // See the matching note in general/create.js: the adapter error carries
+      // no detail worth surfacing, so it is deliberately dropped.
+      .intercept('E_UNIQUE', (unusedErr) => {
         return {conflict: {message: 'A record already exists with that name'}};
       })
       .intercept({name: 'UsageError'}, (err) => {

--- a/api/controllers/pages/create/hosts.js
+++ b/api/controllers/pages/create/hosts.js
@@ -69,7 +69,7 @@ module.exports = {
       Object.assign(data.formItems, await sails.plugins.hostForm(null));
     }
     let tabOrder = await sails.helpers.formTabs.with({ model: data.model, formItems: data.formItems });
-    data.title = `Create New ${data.model.charAt(0).toUpperCase() + data.model.slice(1)}`,
+    data.title = `Create New ${data.model.charAt(0).toUpperCase() + data.model.slice(1)}`;
     data.form = await sails.helpers.formGenerator.with({
       model: data.model,
       method: 'post',

--- a/api/controllers/pages/create/images.js
+++ b/api/controllers/pages/create/images.js
@@ -62,7 +62,7 @@ module.exports = {
       partialname: false
     };
     let partial = path.join(partialPath, `${data.model}.js`);
-    data.title = `Create New ${data.model.charAt(0).toUpperCase() + data.model.slice(1)}`,
+    data.title = `Create New ${data.model.charAt(0).toUpperCase() + data.model.slice(1)}`;
     data.form = await sails.helpers.formGenerator.with({
       model: data.model,
       method: 'post',

--- a/api/controllers/pages/create/users.js
+++ b/api/controllers/pages/create/users.js
@@ -82,7 +82,7 @@ module.exports = {
       partialname: false
     };
     let partial = path.join(partialPath, `${data.model}.js`);
-    data.title = `Create New ${data.model.charAt(0).toUpperCase() + data.model.slice(1)}`,
+    data.title = `Create New ${data.model.charAt(0).toUpperCase() + data.model.slice(1)}`;
     data.form = await sails.helpers.formGenerator.with({
       model: data.model,
       method: 'post',

--- a/api/helpers/datatables/get-data.js
+++ b/api/helpers/datatables/get-data.js
@@ -115,7 +115,7 @@ module.exports = {
           return true;
         }
         if (_.isPlainObject(column.search.value)) {
-          if ((column.search.value.from != '') && (column.search.value.to != '')) {
+          if ((column.search.value.from !== '') && (column.search.value.to !== '')) {
             whereQuery[column.data] = {
               '>=': column.search.value.from,
               '<': column.search.value.to

--- a/api/helpers/system/hwinfo.js
+++ b/api/helpers/system/hwinfo.js
@@ -33,11 +33,15 @@ module.exports = {
     let durr = moment.duration(upsecs);
     let uptime = durr.humanize();
     let hostname = sysinfo.osInfo.hostname;
-    loadaverage = `User: ${user}, Sys: ${sys}, Idle: ${idle}`,
-    cpu = sysinfo.cpu,
-    memory = sysinfo.mem,
-    size = {},
-    setIfaces = ifaceitem => {
+    // These five were a comma-chained assignment with no `let`, so each one
+    // became an implicit global (this file is CommonJS, hence non-strict, so
+    // the assignments silently succeeded). Two concurrent callers of this
+    // helper shared them and would overwrite each other's readings mid-request.
+    let loadaverage = `User: ${user}, Sys: ${sys}, Idle: ${idle}`;
+    let cpu = sysinfo.cpu;
+    let memory = sysinfo.mem;
+    let size = {};
+    let setIfaces = ifaceitem => {
       ifaces.push(ifaceitem);
     };
     // General information
@@ -64,7 +68,8 @@ module.exports = {
 
     // Network information
     for (var i = 0; i < network_ifaces.length; i++) {
-      iface = network_ifaces[i];
+      // Was also undeclared, and so also an implicit global.
+      let iface = network_ifaces[i];
       if (default_iface === iface.iface) {
         serverip = iface.ip4;
       }

--- a/api/models/Role.js
+++ b/api/models/Role.js
@@ -19,15 +19,18 @@ const filterPermissions = function(permissions) {
   // by the 'left' object.
   return _.extend(sails.config.permissions, permissions);
 };
-const deepMap = function(obj, cb) {
+// `mapFn` is a value transform, not a continuation -- its result is assigned,
+// never used for control flow. It was named `cb`, which callback-return reads
+// as a Node-style callback and then (wrongly) demands be returned.
+const deepMap = function(obj, mapFn) {
   let out = {};
 
   Object.keys(obj).forEach((k) => {
     let val;
     if (obj[k] !== null && typeof obj[k] === 'object') {
-      val = deepMap(obj[k], cb);
+      val = deepMap(obj[k], mapFn);
     } else {
-      val = cb(obj[k], k);
+      val = mapFn(obj[k], k);
     }
 
     out[k] = val;

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -18,14 +18,16 @@ const filterPermissions = function(permissions) {
   // by the 'left' object.
   return _.extend(sails.config.permissions, permissions);
 };
-const deepMap = function(obj, cb) {
+// See the matching note in api/models/Role.js: `mapFn` is a value transform,
+// not a continuation, and was named `cb` only by convention.
+const deepMap = function(obj, mapFn) {
   let out = {};
   Object.keys(obj).forEach((k) => {
     let val;
     if (obj[k] !== null && typeof obj[k] === 'object') {
-      val = deepMap(obj[k], cb);
+      val = deepMap(obj[k], mapFn);
     } else {
-      val = cb(obj[k], k);
+      val = mapFn(obj[k], k);
     }
     out[k] = val;
   });

--- a/api/policies/isLoggedIn.js
+++ b/api/policies/isLoggedIn.js
@@ -32,9 +32,12 @@ module.exports = async (req, res, next) => {
       // including the CSRF secret -- so the token rendered on a GET never
       // validates on the following POST (403). Preserve existing session data
       // across the regenerate. (The apitoken path above is stateless: session:false.)
-      await req.login(user, { keepSessionInfo: true }, async (err) => err ? next(err) : next());
+      await req.login(user, { keepSessionInfo: true }, async (err) => {
+        if (err) return next(err);
+        return next();
+      });
     })(req, res);
   } catch (e) {
-    next();
+    return next();
   }
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,7 +42,12 @@ const rules = {
   // moment a body wraps onto its own line, which is the case that actually
   // causes bugs.
   'curly':                        ['warn', 'multi-line'],
-  'eqeqeq':                       ['error', 'always'],
+  // `{null: 'ignore'}` permits `x == null`, which is the standard idiom for
+  // "null or undefined" in one comparison.  Four sites rely on it as a guard
+  // (`String(s == null ? '' : s)`); rewriting those to `===` would silently
+  // stop them catching `undefined`, turning a correct guard into a bug.  Every
+  // other loose comparison is still an error.
+  'eqeqeq':                       ['error', 'always', {'null': 'ignore'}],
   'eol-last':                     ['warn'],
   'handle-callback-err':          ['error'],
   'indent':                       ['warn', 2, {

--- a/tools/migrate/lib/inquire.js
+++ b/tools/migrate/lib/inquire.js
@@ -33,7 +33,7 @@ module.exports = {
           value = parseInt(value, 10);
           if (value > latestRevision) return `You cannot upgrade beyond the latest schema revision of ${latestRevision}`;
           if (value < 1) return 'You cannot downgrade past schema revision 1';
-          if (value == currentRev) return `FOG is already running schema revision ${currentRev}`;
+          if (value === currentRev) return `FOG is already running schema revision ${currentRev}`;
           return true;
         },
       }

--- a/tools/migrate/lib/migration.js
+++ b/tools/migrate/lib/migration.js
@@ -6,8 +6,8 @@ const database = require('../../lib/database');
 const setting = require('../../lib/setting');
 module.exports = {
   getMigrations: (start, end) => {
-    if (start == end) return [];
-    if (start < end && start == end+1) return [];
+    if (start === end) return [];
+    if (start < end && start === end+1) return [];
     let revisions = [];
     let toLoad = [];
     if (start < end) {


### PR DESCRIPTION
First pass over the 207 lint findings #90 left behind. Clears every error except `block-scoped-var` (which is 60 findings across 3 files and gets its own PR).

**Errors: 80 → 60. Total: 207 → 185.** Route suite still 10 passing after each commit.

Three commits, one per rule.

## Two of these were real bugs, not lint nits

### `auth/token.js` returned success on a failed signing

```js
await jwt.sign(..., async (err, token) => {
  return exits.success({token});     // err discarded
});
```

If signing failed, `err` was set and `token` was `undefined`, and the endpoint still answered **200 with `{token: undefined}`** — handing the caller a success it couldn't use and throwing away the cause. It now mirrors `auth/login.js`, which signs with the same config and already checks both.

### `helpers/system/hwinfo.js` leaked six implicit globals

```js
loadaverage = `User: ${user}, ...`,
cpu = sysinfo.cpu,
memory = sysinfo.mem,
size = {},
setIfaces = ifaceitem => { ifaces.push(ifaceitem); };
```

No `let`. The file is CommonJS and therefore non-strict, so rather than throwing, all five became **globals** — plus `iface` in the interface loop below. Every caller shared one copy, so two concurrent `/system/info` requests would overwrite each other's readings mid-request. All six are now `let`.

`no-undef` is off for backend code, which is why neither was ever caught.

## `eqeqeq` (10) — split two ways

Four are `x == null`, the standard one-comparison idiom for "null **or** undefined", used as a guard: `String(s == null ? '' : s)`. Rewriting those to `===` would stop them catching `undefined` and turn a correct guard into a bug — so the rule now carries `{null: 'ignore'}`, the option that exists for exactly this. Everything else stays strict.

The other six are genuine. I traced the types on each before touching it, since `==` is only load-bearing when the sides differ in type:

- `auth/login.js`, `datatables/get-data.js` — HTTP request values, so string or undefined; `===`/`!==` are identical here.
- `migrate/lib/migration.js` ×2, `migrate/lib/inquire.js` — schema revisions, numbers on both sides: `getCurrentRevision` returns `parseInt(value.revision, 10)`, and the target is `cfg.schema`, a numeric literal in `config/local.js` and written as `cfg.schema = 1` by both seed tools.

## `callback-return` (3) — all false positives, fixed at the cause

`Role.js` and `User.js` each define `deepMap(obj, cb)` whose `cb` is a **value transform** — its result is assigned, never used for control flow — but the rule treats anything named `cb` as a continuation needing `return`. Adding one would have broken the function. Renamed to `mapFn`. The third was a concise arrow that already returns its body via a ternary; expanded to an explicit block.

## `no-sequences` (4)

Besides the `hwinfo.js` bug above, three were a comma where a semicolon was meant (`data.title = ...,` in the three `pages/create/*` controllers). Both assignments did happen, so that part is readability only.

## Left alone

`migration.js:10` reads `if (start < end && start === end+1)`. When `start < end` holds, `start === end+1` cannot — the branch is unreachable. Flagged rather than changed, since the intent isn't clear and altering it would change behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)