### PR TITLE
fix(lint): resolve block-scoped-var — lint errors now at zero

### DIFF
--- a/api/helpers/datatables/get-data.js
+++ b/api/helpers/datatables/get-data.js
@@ -114,6 +114,11 @@ module.exports = {
           }
           return true;
         }
+        // Declared once here rather than repeated with `var` in each branch
+        // below. All four copies computed this identical expression, and the
+        // unconditional one further down recomputed it a fifth time, so a
+        // single block-scoped binding is equivalent.
+        let col = column.data.split('.')[0];
         if (_.isPlainObject(column.search.value)) {
           if ((column.search.value.from !== '') && (column.search.value.to !== '')) {
             whereQuery[column.data] = {
@@ -122,22 +127,17 @@ module.exports = {
             };
           }
         } else if (_.isString(column.search.value)) {
-          var col = column.data.split('.')[0];
           var regexp = new RegExp(column.search.value, 'i');
           if (!_.isEqual(column.search.value, '')) {
             whereQuery[col] = regexp;
           }
         } else if (_.isNumber(column.search.value)) {
-          var col = column.data.split('.')[0];
           whereQuery[col] = column.search.value;
         } else if (_.isArray(column.search.value)) {
-          var col = column.data.split('.')[0];
           whereQuery[col] = column.search.value;
         }
 
         // This handles the global search function of this column
-        var col = column.data.split('.')[0];
-
         var filter = {};
         if (!_.isEqual(_options.search.value, '')) {
           filter[col] = {

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -72,8 +72,8 @@ module.exports = {
       let permissions = {};
       if (roles === undefined) return {};
       if (models === undefined) models = Object.keys(sails.models);
-      for (var i = 0; i < models.length; i++) {
-        for (var j = 0; j < roles.length; j++) {
+      for (let i = 0; i < models.length; i++) {
+        for (let j = 0; j < roles.length; j++) {
           if (roles[j].isAdmin) {
             roles[j].permissions = deepMap(sails.config.permissions, (v, k) => {
               return true;
@@ -83,7 +83,7 @@ module.exports = {
           }
         }
       }
-      for (var i = 0; i < roles.length; i++) {
+      for (let i = 0; i < roles.length; i++) {
         permissions = _.extend(permissions, roles[i].permissions);
       }
       return permissions;

--- a/tools/migrate/lib/migration.js
+++ b/tools/migrate/lib/migration.js
@@ -11,16 +11,16 @@ module.exports = {
     let revisions = [];
     let toLoad = [];
     if (start < end) {
-      for (var i = start + 1; i <= end; i++) {
+      for (let i = start + 1; i <= end; i++) {
         toLoad.push(i);
       }
     } else {
-      for (var i = start; i > end; i--) {
+      for (let i = start; i > end; i--) {
         toLoad.push(i);
       }
     }
 
-    for (var i = 0; i < toLoad.length; i++) {
+    for (let i = 0; i < toLoad.length; i++) {
       try {
         revisions[i] = require(path.join(migrationsFolder, toLoad[i]));
         revisions[i]._meta.schema = toLoad[i];


### PR DESCRIPTION
The last 60 lint errors. **Errors: 60 → 0.** Total: 185 → 119 (all warnings now).

Three files, two distinct causes.

## Loop counters — `tools/migrate/lib/migration.js`, `api/models/User.js`

Each declares `var i` in sibling for-loops inside one function. `var` is function-scoped, so those are all *the same binding*, and the rule reports every cross-reference between them — three loops in `migration.js` generate 32 findings by themselves. Headers now use `let`.

`var` → `let` in a loop header only changes behaviour in two situations: a closure captures the counter (per-iteration binding rather than one shared one), or something reads it after the loop. **Neither applies here** — the only inner function is `(v, k) => true` in `User.js`, which references neither counter, and no counter is read after its loop. `User.js`'s inner `var j` went along for consistency within the same construct.

## Repeated declaration — `api/helpers/datatables/get-data.js`

`var col` was declared four times — once in each of three `else if` branches, then again unconditionally below them — each computing the identical `column.data.split('.')[0]`:

```js
} else if (_.isString(column.search.value)) {
  var col = column.data.split('.')[0];
  ...
} else if (_.isNumber(column.search.value)) {
  var col = column.data.split('.')[0];
  ...
// This handles the global search function of this column
var col = column.data.split('.')[0];
```

Replaced with a single `let col` above the chain. It sits *after* the three early `return true` guards, so it's reached in exactly the cases the originals were, and the expression is pure — every read sees the value it saw before.

## Verification

Beyond lint and the route suite, I exercised `getMigrations()` directly and diffed it against master across upgrade, downgrade, no-op and missing-file cases:

```
1,1=2|3,3=2|1,3=E:Missing migration file for schema 2|3,1=E:Missing migration file for schema 3|
2,4=E:Missing migration file for schema 3|4,2=E:Missing migration file for schema 4|0,0=2|5,5=2

→ IDENTICAL BEHAVIOUR (old vs new)
```

Identical output, including which schema each direction reports as missing first — which is what confirms the loop ordering survived.

Route suite still 10 passing; all changed files parse.

## Where this leaves things

`no-redeclare` also fell 8 → 2 as a side effect, since the duplicate `var i` declarations were redeclarations too.

Remaining 119, all warnings: `no-unused-vars` 97, `camelcase` 20, `no-redeclare` 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)