### PR TITLE
fix(lint): clear the last 119 findings — npm test green end to end

### DIFF
--- a/api/controllers/auth/logout.js
+++ b/api/controllers/auth/logout.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   exits: {
   },
-  fn: async function (inputs) {
+  fn: async function () {
     let req = this.req;
     let res = this.res;
     // passport >= 0.6 made req.logout() asynchronous -- it requires a callback

--- a/api/controllers/auth/token.js
+++ b/api/controllers/auth/token.js
@@ -1,6 +1,5 @@
 const jwt = require('jsonwebtoken');
 const jwtConfig = sails.config.auth.jwt;
-const passport = require('passport');
 module.exports = {
   friendlyName: 'Token',
   description: 'Token auth.',
@@ -11,7 +10,6 @@ module.exports = {
   },
   fn: async function (inputs, exits) {
     let req = this.req;
-    let res = this.res;
     await jwt.sign({user: req.user.id}, jwtConfig.secret, jwtConfig.options, async (err, token) => {
       // Without these the endpoint answered 200 with `{token: undefined}`
       // whenever signing failed, handing the caller a success it could not

--- a/api/controllers/general/create.js
+++ b/api/controllers/general/create.js
@@ -17,7 +17,6 @@ module.exports = {
   },
   fn: async function() {
     let req = this.req;
-    let res = this.res;
     let params = req.allParams();
     let model = params.model;
     // API-token requests may never write credentials (password / apiTokenHash).

--- a/api/controllers/general/destroy.js
+++ b/api/controllers/general/destroy.js
@@ -3,7 +3,6 @@ module.exports = {
   description: 'Destroy user.',
   fn: async function () {
     let req = this.req;
-    let res = this.res;
     let params = req.allParams();
     let id = params.id;
     let model = params.model;

--- a/api/controllers/general/find.js
+++ b/api/controllers/general/find.js
@@ -3,7 +3,6 @@ module.exports = {
   description: 'Find user.',
   fn: async function () {
     let req = this.req;
-    let res = this.res;
     let params = req.allParams();
     let model = params.model;
     let id = params.id;

--- a/api/controllers/general/list.js
+++ b/api/controllers/general/list.js
@@ -3,7 +3,6 @@ module.exports = {
   description: 'List Items.',
   fn: async function () {
     let req = this.req;
-    let res = this.res;
     let params = req.allParams();
     let model = params.model;
     return await sails.models[model].find().populateAll();

--- a/api/controllers/general/search.js
+++ b/api/controllers/general/search.js
@@ -3,7 +3,6 @@ module.exports = {
   description: 'Search item',
   fn: async function () {
     let req = this.req;
-    let res = this.res;
     let params = req.allParams();
     let query = req.query;
     let model = params.model;

--- a/api/controllers/general/update.js
+++ b/api/controllers/general/update.js
@@ -17,14 +17,11 @@ module.exports = {
   },
   fn: async function() {
     let req = this.req;
-    let res = this.res;
     let params = req.allParams();
     let model = params.model;
     let id = params.id;
     // API-token requests may never write credentials (password / apiTokenHash).
     if (req.authVia === 'apitoken') { delete params.password; delete params.apiTokenHash; }
-    let orig = [];
-    let toRem = [];
     let obj = await sails.models[model].updateOne({id}, params)
       // See the matching note in general/create.js: the adapter error carries
       // no detail worth surfacing, so it is deliberately dropped.

--- a/api/controllers/image/capture.js
+++ b/api/controllers/image/capture.js
@@ -18,7 +18,6 @@ module.exports = {
     let req = this.req;
     let res = this.res;
     let params = req.allParams();
-    let id = params.id;
     res.setTimeout(0);
     await req.file('image').upload({}, async function whenDone(err, uploadedFiles) {
       if (err) return exits.error(err);

--- a/api/controllers/pages/create/hosts.js
+++ b/api/controllers/pages/create/hosts.js
@@ -10,8 +10,6 @@ module.exports = {
     }
   },
   fn: async function () {
-    let req = this.req;
-    let res = this.res;
     let data = {
       model: 'host',
       header: 'Create New Host',

--- a/api/controllers/pages/create/images.js
+++ b/api/controllers/pages/create/images.js
@@ -10,8 +10,6 @@ module.exports = {
     }
   },
   fn: async function () {
-    let req = this.req;
-    let res = this.res;
     let data = {
       model: 'image',
       header: 'Create New Image',

--- a/api/controllers/pages/create/users.js
+++ b/api/controllers/pages/create/users.js
@@ -10,8 +10,6 @@ module.exports = {
     }
   },
   fn: async function () {
-    let req = this.req;
-    let res = this.res;
     let data = {
       model: 'user',
       header: 'Create New User',

--- a/api/controllers/pages/dashboard.js
+++ b/api/controllers/pages/dashboard.js
@@ -51,7 +51,7 @@ module.exports = {
       try {
         let diskSpace = await checkDiskSpace(path.parse(appRoot).root);
         size = diskSpace.size; free = diskSpace.free; used = size - free;
-      } catch (unused2) { /* leave zeros */ }
+      } catch (unusedErr) { /* leave zeros */ }
     }
 
     let legend = [

--- a/api/controllers/pages/list/hosts.js
+++ b/api/controllers/pages/list/hosts.js
@@ -15,9 +15,7 @@ module.exports = {
       description: 'Successful'
     }
   },
-  fn: async function (inputs) {
-    let req = this.req;
-    let res = this.res;
+  fn: async function () {
     let data = {
       header: 'Host List',
       theads: [

--- a/api/controllers/pages/list/images.js
+++ b/api/controllers/pages/list/images.js
@@ -15,9 +15,7 @@ module.exports = {
       description: 'Successful'
     }
   },
-  fn: async function (inputs) {
-    let req = this.req;
-    let res = this.res;
+  fn: async function () {
     let data = {
       header: 'Image List',
       theads: [

--- a/api/controllers/pages/list/pxemenus.js
+++ b/api/controllers/pages/list/pxemenus.js
@@ -15,7 +15,7 @@ module.exports = {
       description: 'Successful'
     }
   },
-  fn: async function (inputs) {
+  fn: async function () {
     let data = {
       header: 'iPXE Menu List',
       theads: [

--- a/api/controllers/pages/list/roles.js
+++ b/api/controllers/pages/list/roles.js
@@ -15,9 +15,7 @@ module.exports = {
       description: 'Successful'
     }
   },
-  fn: async function (inputs) {
-    let req = this.req;
-    let res = this.res;
+  fn: async function () {
     let data = {
       header: 'Role List',
       theads: [

--- a/api/controllers/pages/list/storagegroups.js
+++ b/api/controllers/pages/list/storagegroups.js
@@ -15,7 +15,7 @@ module.exports = {
       description: 'Successful'
     }
   },
-  fn: async function (inputs) {
+  fn: async function () {
     let data = {
       header: 'Storage Group List',
       theads: [

--- a/api/controllers/pages/list/storagenodes.js
+++ b/api/controllers/pages/list/storagenodes.js
@@ -15,7 +15,7 @@ module.exports = {
       description: 'Successful'
     }
   },
-  fn: async function (inputs) {
+  fn: async function () {
     let data = {
       header: 'Storage Node List',
       theads: [

--- a/api/controllers/pages/list/tasks.js
+++ b/api/controllers/pages/list/tasks.js
@@ -15,9 +15,7 @@ module.exports = {
       description: 'Successful'
     }
   },
-  fn: async function (inputs) {
-    let req = this.req;
-    let res = this.res;
+  fn: async function () {
     let data = {
       header: 'Task List',
       theads: [

--- a/api/controllers/pages/list/users.js
+++ b/api/controllers/pages/list/users.js
@@ -15,9 +15,7 @@ module.exports = {
       description: 'Successful'
     }
   },
-  fn: async function (inputs) {
-    let req = this.req;
-    let res = this.res;
+  fn: async function () {
     let data = {
       header: 'User List',
       theads: [

--- a/api/controllers/pages/list/workflows.js
+++ b/api/controllers/pages/list/workflows.js
@@ -15,9 +15,7 @@ module.exports = {
       description: 'Successful'
     }
   },
-  fn: async function (inputs) {
-    let req = this.req;
-    let res = this.res;
+  fn: async function () {
     let data = {
       header: 'Workflow List',
       theads: [

--- a/api/controllers/role/assign.js
+++ b/api/controllers/role/assign.js
@@ -3,7 +3,6 @@ module.exports = {
   description: 'Assign users to this role.',
   fn: async function () {
     let req = this.req;
-    let res = this.res;
     let params = req.allParams();
     let id = params.id;
     let users = params.users;

--- a/api/controllers/role/unassign.js
+++ b/api/controllers/role/unassign.js
@@ -3,7 +3,6 @@ module.exports = {
   description: 'Unassign users from this role.',
   fn: async function () {
     let req = this.req;
-    let res = this.res;
     let params = req.allParams();
     let id = params.id;
     let users = params.users;

--- a/api/controllers/system/bandwidth.js
+++ b/api/controllers/system/bandwidth.js
@@ -7,10 +7,11 @@ module.exports = {
   exits: {
   },
   fn: async function () {
-    let default_iface = await si.networkInterfaceDefault();
-    let netstats = await si.networkStats(default_iface);
+    let defaultIface = await si.networkInterfaceDefault();
+    let netstats = await si.networkStats(defaultIface);
     return {
-      default_iface,
+      // Key kept snake_case: it is part of the /bandwidth response shape.
+      default_iface: defaultIface,
       netstats
     };
   }

--- a/api/controllers/system/bandwidth.js
+++ b/api/controllers/system/bandwidth.js
@@ -1,5 +1,4 @@
 const si = require('systeminformation');
-const moment = require('moment');
 module.exports = {
   friendlyName: 'Bandwidth',
   description: 'Bandwidth system.',
@@ -7,7 +6,7 @@ module.exports = {
   },
   exits: {
   },
-  fn: async function (inputs) {
+  fn: async function () {
     let default_iface = await si.networkInterfaceDefault();
     let netstats = await si.networkStats(default_iface);
     return {

--- a/api/controllers/system/info.js
+++ b/api/controllers/system/info.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   exits: {
   },
-  fn: async function (inputs) {
+  fn: async function () {
     let options = {
       time: 'uptime',
       currentLoad: 'currentLoadUser, currentLoadSystem, currentLoadIdle',

--- a/api/controllers/system/system.js
+++ b/api/controllers/system/system.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   exits: {
   },
-  fn: async function (inputs) {
+  fn: async function () {
     return await sails.helpers.system.hwinfo();
   }
 };

--- a/api/controllers/user/listme.js
+++ b/api/controllers/user/listme.js
@@ -1,7 +1,7 @@
 module.exports = {
   friendlyName: 'Listme',
   description: 'Listme user.',
-  fn: async function(inputs) {
+  fn: async function() {
     let req = this.req;
     return req.user;
   }

--- a/api/helpers/datatables/get-columns.js
+++ b/api/helpers/datatables/get-columns.js
@@ -21,7 +21,6 @@ module.exports = {
   },
   fn: async function (inputs) {
     let req = inputs.req;
-    let res = inputs.res;
     let params = req.allParams();
     let model = params.model;
 

--- a/api/helpers/datatables/get-data.js
+++ b/api/helpers/datatables/get-data.js
@@ -85,7 +85,7 @@ module.exports = {
     var where = [];
     var whereQuery = {or: []};
     var select = [];
-    var order = [];
+    var sortOrder = [];
 
     if (_.isArray(_options.columns)) {
       _options.columns.forEach((column) => {
@@ -161,7 +161,7 @@ module.exports = {
       }
       var sortDir = value.dir.toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
       sortColumn[sortBy] = sortDir;
-      order.push(sortColumn);
+      sortOrder.push(sortColumn);
     });
 
     // Find the database on the query and total items in teh database;
@@ -174,7 +174,7 @@ module.exports = {
       where: whereQuery,
       skip: +_options.start || -1,
       limit: +_options.length || -1,
-      sort: order
+      sort: sortOrder
     };
 
     if (findOpts.skip < 1) delete findOpts.skip;

--- a/api/helpers/datatables/get-data.js
+++ b/api/helpers/datatables/get-data.js
@@ -21,7 +21,6 @@ module.exports = {
   },
   fn: async function (inputs, exits) {
     var req = inputs.req;
-    var res = inputs.res;
     var params = req.allParams();
     var model = params.model;
     var options = params.options || params || {};
@@ -89,7 +88,7 @@ module.exports = {
     var order = [];
 
     if (_.isArray(_options.columns)) {
-      _options.columns.forEach((column, index) => {
+      _options.columns.forEach((column) => {
         if (_.isNull(column.data) || !column.searchable) return true;
         var columnType = false;
         if (!_.isUndefined(model.attributes[column.data])) {
@@ -105,12 +104,16 @@ module.exports = {
           }
           _reverse.model = sails.models[association.model || association.collection];
           var joinedCriteria = _.split(column.data, '.', 2)[1];
-          if (_.isUndefined(joinCriteria)) {
+          // Both reads below said `joinCriteria` -- no `ed` -- which is not
+          // declared anywhere. Reading an undeclared name throws rather than
+          // yielding undefined, so this whole reverse-association branch
+          // raised a ReferenceError and 500'd for any column using `reverse`.
+          if (_.isUndefined(joinedCriteria)) {
             _reverse.criteria = {
               id: column.search.value
             };
           } else {
-            _reverse[joinCriteria] = column.search.value;
+            _reverse[joinedCriteria] = column.search.value;
           }
           return true;
         }
@@ -151,7 +154,7 @@ module.exports = {
     whereQuery.or = where;
 
     var sortColumn = {};
-    _.forEach(_options.order, (value, key) => {
+    _.forEach(_options.order, (value) => {
       var sortBy = _options.columns[value.column].data;
       if (_.includes(sortBy, '.')) {
         sortBy = sortBy.substr(0, sortBy.indexOf('.'));

--- a/api/helpers/image/stream.js
+++ b/api/helpers/image/stream.js
@@ -47,7 +47,7 @@ module.exports = {
       invalid: async (err) => {
         return exits.invalid(err);
       },
-      success: (image) => {
+      success: () => {
         let partitionPath = path.join(imageDir, id, `${partition}.img`);
         sails.log.info(`Reading: ${partitionPath}`);
         fs.exists(partitionPath, (err, exists) => {

--- a/api/helpers/system/hwinfo.js
+++ b/api/helpers/system/hwinfo.js
@@ -12,8 +12,8 @@ module.exports = {
     },
   },
   fn: async function () {
-    let default_iface = await si.networkInterfaceDefault();
-    let network_ifaces = await si.networkInterfaces();
+    let defaultIface = await si.networkInterfaceDefault();
+    let networkIfaces = await si.networkInterfaces();
     let ifaces = [];
     let serverip;
     let sysinfo = await si.get({
@@ -64,15 +64,15 @@ module.exports = {
     });
 
     // Network information
-    for (var i = 0; i < network_ifaces.length; i++) {
+    for (var i = 0; i < networkIfaces.length; i++) {
       // Was also undeclared, and so also an implicit global.
-      let iface = network_ifaces[i];
-      if (default_iface === iface.iface) {
+      let iface = networkIfaces[i];
+      if (defaultIface === iface.iface) {
         serverip = iface.ip4;
       }
       await si.networkStats(iface.iface).then(async tmpi => {
         tmpi.forEach(async tmp => {
-          let netif = network_ifaces.find(n => n.iface === tmp.iface);
+          let netif = networkIfaces.find(n => n.iface === tmp.iface);
           setIfaces({
             name: tmp.iface,
             mac: (netif && netif.mac) ? netif.mac : '',

--- a/api/helpers/system/hwinfo.js
+++ b/api/helpers/system/hwinfo.js
@@ -1,7 +1,4 @@
 const si = require('systeminformation');
-const fs = require('fs-extra');
-const path = require('path');
-const appRoot = path.join(__dirname, '..', '..', '..');
 const moment = require('moment');
 const checkDiskSpace = require('check-disk-space').default;
 module.exports = {
@@ -14,7 +11,7 @@ module.exports = {
       description: 'All done.',
     },
   },
-  fn: async function (inputs) {
+  fn: async function () {
     let default_iface = await si.networkInterfaceDefault();
     let network_ifaces = await si.networkInterfaces();
     let ifaces = [];

--- a/api/hooks/fog-version/index.js
+++ b/api/hooks/fog-version/index.js
@@ -19,7 +19,7 @@ const safeReadJSON = filepath => {
   }
   return JSON.parse(raw) || {};
 };
-module.exports = function defineFogVersionHook(sails) {
+module.exports = function defineFogVersionHook() {
   return {
     routes: {
       /**

--- a/api/models/Role.js
+++ b/api/models/Role.js
@@ -64,7 +64,7 @@ module.exports = {
   },
   customToJSON: function() {
     if (this.isAdmin) {
-      this.permissions = deepMap(sails.config.permissions, (v, k) => {
+      this.permissions = deepMap(sails.config.permissions, () => {
         return true;
       });
     } else {
@@ -74,7 +74,7 @@ module.exports = {
   },
   beforeCreate: function(values, next) {
     if (values.isAdmin) {
-      values.permissions = deepMap(sails.config.permissions, (v, k) => {
+      values.permissions = deepMap(sails.config.permissions, () => {
         return true;
       });
     } else {
@@ -87,7 +87,7 @@ module.exports = {
     if (values.hasOwnProperty('permissions') && !values.isAdmin) {
       values.permissions = filterPermissions(values.permissions);
     } else if (values.isAdmin) {
-      values.permissions = deepMap(sails.config.permissions, (v, k) => {
+      values.permissions = deepMap(sails.config.permissions, () => {
         return true;
       });
     }

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -75,7 +75,7 @@ module.exports = {
       for (let i = 0; i < models.length; i++) {
         for (let j = 0; j < roles.length; j++) {
           if (roles[j].isAdmin) {
-            roles[j].permissions = deepMap(sails.config.permissions, (v, k) => {
+            roles[j].permissions = deepMap(sails.config.permissions, () => {
               return true;
             });
           } else {

--- a/api/policies/isLoggedIn.js
+++ b/api/policies/isLoggedIn.js
@@ -37,7 +37,7 @@ module.exports = async (req, res, next) => {
         return next();
       });
     })(req, res);
-  } catch (e) {
+  } catch (unusedErr) {
     return next();
   }
 };

--- a/api/services/MacVendor.js
+++ b/api/services/MacVendor.js
@@ -14,7 +14,7 @@
 let DB = {};
 try {
   DB = require('./mac-oui.json');
-} catch (e) {
+} catch (unusedErr) {
   // Snapshot missing (not yet generated) -- degrade to "no vendor known"
   // rather than crash. Run scripts/build-oui.js to populate it.
   sails && sails.log ? sails.log.warn('MacVendor: mac-oui.json not found; vendor labels disabled. Run scripts/build-oui.js') : null;

--- a/assets/fog/fog.common.js
+++ b/assets/fog/fog.common.js
@@ -29,14 +29,14 @@ $.fn.registerTable = function(onSelect, opts) {
       },
       {
         text: '<i class="fa fa-refresh"></i> Refresh',
-        action: function(e, dt, node, config) {
+        action: function(e, dt) {
           dt.clear().draw();
           dt.ajax.reload();
         }
       },
       {
         text: '<i class="fa fa-edit"></i> Edit',
-        action: function(e, dt, node, config) {
+        action: function(e, dt) {
           let rows = dt.rows({selected: true}).data().toArray();
           if (rows.length !== 1) {
             window.fogToast('error', 'Select exactly one row to edit.');
@@ -49,7 +49,7 @@ $.fn.registerTable = function(onSelect, opts) {
       {
         text: '<i class="fa fa-trash"></i> Delete',
         className: 'btn-danger',
-        action: function(e, dt, node, config) {
+        action: function(e, dt) {
           let ids = dt.rows({selected: true}).data().toArray().map((r) => r.id).filter(Boolean);
           if (!ids.length) {
             window.fogToast('error', 'Select one or more rows to delete.');
@@ -125,7 +125,7 @@ $.fn.registerTable = function(onSelect, opts) {
   let table = $(this).DataTable(opts);
 
   if (onSelect !== undefined && typeof onSelect === 'function') {
-    table.on('select deselect', (e, dt, type, indexes) => {
+    table.on('select deselect', (e, dt) => {
       onSelect(dt.rows({selected: true}));
     });
   }
@@ -148,7 +148,7 @@ $.readableBytes = function(bytes) {
       if (window.PNotify && typeof PNotify.alert === 'function') {
         PNotify.alert({ type: type, text: text, delay: 2500 });
       }
-    } catch (e) { /* toast is best-effort; the reloaded row is the real feedback */ }
+    } catch (unusedErr) { /* toast is best-effort; the reloaded row is the real feedback */ }
   }
   function clearError(container) {
     let e = container.querySelector('.fog-form-error');
@@ -244,7 +244,7 @@ $.readableBytes = function(bytes) {
         PNotify.alert({ type: type === 'error' ? 'error' : type, text: text, delay: 3000 });
         return;
       }
-    } catch (e) { /* fall through to native */ }
+    } catch (unusedErr) { /* fall through to native */ }
     window.alert(text);
   }
 

--- a/config/passport/jwt.js
+++ b/config/passport/jwt.js
@@ -1,6 +1,5 @@
 const passport = require('passport');
 const JWTStrategy = require('passport-jwt-cookiecombo');
-const jwt = require('jsonwebtoken');
 const locals = require('../../config/local');
 const opts = {
   secretOrPublicKey: locals.auth.jwt.secret,

--- a/config/passport/jwt.js
+++ b/config/passport/jwt.js
@@ -20,10 +20,10 @@ passport.deserializeUser(async (id, done) => {
   });
 });
 passport.use(new JWTStrategy(opts,
-  async (jwt_payload, done) => {
-    if (!jwt_payload) return done(null, false, {message: 'No token passed'});
-    if (!jwt_payload.user) return done(null, false, {message: 'No user information present'});
-    await User.findOne({id: jwt_payload.user}).populateAll().exec(async (err, user) => {
+  async (jwtPayload, done) => {
+    if (!jwtPayload) return done(null, false, {message: 'No token passed'});
+    if (!jwtPayload.user) return done(null, false, {message: 'No user information present'});
+    await User.findOne({id: jwtPayload.user}).populateAll().exec(async (err, user) => {
       if (err) return done(err, false, {message: 'An error occurred locating the user'});
       if (user) {
         user.isLocalAuth = true;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,7 +33,14 @@ const globals = require('globals');
 const rules = {
   'block-scoped-var':             ['error'],
   'callback-return':              ['error', ['done', 'proceed', 'next', 'onwards', 'callback', 'cb']],
-  'camelcase':                    ['warn', {'properties':'always'}],
+  // `allow` lists snake_case names that are wire format, not style drift:
+  // they are keys in the JSON returned by /system/info and /bandwidth, and the
+  // tx_/rx_ set mirrors the field names the `systeminformation` package hands
+  // us. Renaming them would change a public API response for cosmetic reasons.
+  // Purely internal snake_case locals are still reported.
+  'camelcase':                    ['warn', {'properties':'always', 'allow': [
+    '^default_iface$', '^(tx|rx)_(bytes|errors|dropped|sec)$'
+  ]}],
   'comma-style':                  ['warn', 'last'],
   // 'multi-line' rather than the template's default 'all'.  Every one of the
   // 125 hits the stricter setting produced was a single-line guard clause

--- a/plugins/wol/index.js
+++ b/plugins/wol/index.js
@@ -39,7 +39,7 @@ module.exports = {
       let sent = [];
       let failed = [];
       for (let mac of macs) {
-        try { await sendMagicPacket(mac); sent.push(mac); } catch (err) { failed.push(mac); }
+        try { await sendMagicPacket(mac); sent.push(mac); } catch (unusedErr) { failed.push(mac); }
       }
       return res.json({ host: host.name, sent, failed });
     }

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -1,6 +1,4 @@
 const sails = require('sails');
-var roleadmin = {};
-var useradmin = {};
 
 before(function(done) {
   this.timeout(11000);
@@ -23,7 +21,7 @@ before(function(done) {
             password: 'mochatestadmin',
             email: 'mochatest@admin.com',
             roles: [role.id]
-          }, (err, user) => {
+          }, (err) => {
             if (err) return done(err);
             done();
           }

--- a/test/route/routes.test.js
+++ b/test/route/routes.test.js
@@ -68,7 +68,7 @@ describe('Route tests::', () =>  {
       supertest(sails.hooks.http.app)[method](args)
         .set('Authorization', token)
         .set('X-Requested-With', 'XMLHttpRequest');
-  var request = {
+  request = {
     post: hook('post'),
     get: hook('get'),
     put: hook('put'),

--- a/tools/lib/database.js
+++ b/tools/lib/database.js
@@ -2,8 +2,8 @@ const MongoClient = require('mongodb').MongoClient;
 
 module.exports = {
   connect: (host, port, database, username, password, next) => {
-    let db_uri = 'mongodb://';
-    db_uri += `${host}:${port}/${database}`;
+    let dbUri = 'mongodb://';
+    dbUri += `${host}:${port}/${database}`;
     let opts = {
       useUnifiedTopology: true,
       useNewUrlParser: true
@@ -17,7 +17,7 @@ module.exports = {
         password: password
       };
     }
-    MongoClient.connect(db_uri, opts, (err, db) => {
+    MongoClient.connect(dbUri, opts, (err, db) => {
       if (err) return next(err);
       next(null, db);
     });

--- a/tools/lib/setting.js
+++ b/tools/lib/setting.js
@@ -1,6 +1,6 @@
 module.exports = {
   create: (db, name, value, next) => {
-    db.collection('setting').insert({name,value}, (err, setting) => {
+    db.collection('setting').insert({name,value}, (err) => {
       if (err) return next(err);
       next();
     });

--- a/tools/migrate/index.js
+++ b/tools/migrate/index.js
@@ -8,7 +8,6 @@ const inquire = require('./lib/inquire');
 const migrations = require('./lib/migration');
 const welcome = 'Welcome to the FOG Schema Migrator.\nYou will be guided through migrating your current database schema';
 var COMPLETED = false;
-var revision = 0;
 
 header.print(welcome);
 async.waterfall([
@@ -48,7 +47,7 @@ async.waterfall([
       next();
     });
   }
-], (err, result) => {
+], (err) => {
   if (err) console.log(chalk.bgRed(err));
   COMPLETED = true;
   process.exit();

--- a/tools/migrate/lib/inquire.js
+++ b/tools/migrate/lib/inquire.js
@@ -38,5 +38,11 @@ module.exports = {
         },
       }
     ];
+    // This was missing: the function built `questions`, then returned without
+    // prompting or ever calling `next`, so it could only ever be a no-op. Same
+    // shape as getBackupInfo above. Nothing calls getSchemaVersion today --
+    // tools/migrate/index.js only uses getBackupInfo -- which is why the gap
+    // went unnoticed.
+    inquirer.prompt(questions).then(next);
   }
 };

--- a/tools/migrate/lib/migration.js
+++ b/tools/migrate/lib/migration.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 const migrationsFolder = path.join(__dirname, '..', '..', '..', 'migrations');
 const config = require('../../lib/config');
@@ -24,7 +23,7 @@ module.exports = {
       try {
         revisions[i] = require(path.join(migrationsFolder, toLoad[i]));
         revisions[i]._meta.schema = toLoad[i];
-      } catch (e) {
+      } catch (unusedErr) {
         throw `Missing migration file for schema ${toLoad[i]}`;
       }
     }

--- a/tools/setup/index.js
+++ b/tools/setup/index.js
@@ -242,7 +242,7 @@ module.exports.http = {
     console.log(`Password: ${payload.admin.password}`);
     next();
   }
-], (err, result) => {
+], (err) => {
   if (err) console.log(chalk.bgRed(err));
   COMPLETED = true;
   process.exit();

--- a/tools/setup/lib/inquire.js
+++ b/tools/setup/lib/inquire.js
@@ -6,7 +6,7 @@ const database = require('../../lib/database');
 const verifyDB = (answers, next) => {
   let status = new Spinner('Verifying database information, please wait...');
   status.start();
-  database.connect(answers.host, answers.port, answers.database, answers.username, answers.password, (err, db) => {
+  database.connect(answers.host, answers.port, answers.database, answers.username, answers.password, (err) => {
     status.stop();
     let prefix = 'MongoError: ';
     if (err) {

--- a/tools/setup/lib/schema.js
+++ b/tools/setup/lib/schema.js
@@ -34,12 +34,12 @@ module.exports = {
       if (err) return next(err);
       if (!cfg.schema) cfg.schema = 1;
       schema.value.revision = cfg.schema;
-      await Setting.findOrCreate({name: schema.name}, schema, async (err, setting) => {
+      await Setting.findOrCreate({name: schema.name}, schema, async (err) => {
         if (err) return next(err);
         await Role.findOrCreate({name: adminRole.name}, adminRole, async (err, role) => {
           if (err) return next(err);
           adminUser.roles = [role.id];
-          await User.findOrCreate({username: adminUser.username}, adminUser, async (err, user) => {
+          await User.findOrCreate({username: adminUser.username}, adminUser, async (err) => {
             if (err) return next(err);
             next();
           });

--- a/tools/setup/seed-demo.js
+++ b/tools/setup/seed-demo.js
@@ -26,7 +26,7 @@ const config = require('../lib/config');
 let OUI_DB = {};
 try {
   OUI_DB = require(path.join(config.appPath, 'api', 'services', 'mac-oui.json'));
-} catch (e) {
+} catch (unusedErr) {
   OUI_DB = {};
 }
 

--- a/views/pages/partials/dashboard.js
+++ b/views/pages/partials/dashboard.js
@@ -142,8 +142,6 @@
   let bandwidthSamples = [];      // {t, label, rx, tx}; retained up to MAX_RETAIN
   let bandwidthIface = '';
   let bandwidthWindowSec = 120;   // selected DISPLAY window (default: 2 minutes)
-  let bandwidthinterval;
-  let bandwidthajax;
 
   function bandwidthCanvas(data) {
     let bandwidth = $('#bandwidth').get(0);
@@ -186,7 +184,7 @@
 
   function updateBandwidth() {
     function fetchData() {
-      bandwidthajax = $.ajax({
+      $.ajax({
         url: '/bandwidth',
         type: 'get',
         dataType: 'json',
@@ -208,7 +206,7 @@
           renderBandwidth(now);
         },
         complete: function() {
-          bandwidthinterval = setTimeout(fetchData, 2000);
+          setTimeout(fetchData, 2000);
         }
       });
     }

--- a/views/pages/partials/login.js
+++ b/views/pages/partials/login.js
@@ -1,3 +1,3 @@
-(function($) {
+(function() {
 
 })(jQuery);


### PR DESCRIPTION
The last of the lint backlog. **119 → 0.** `npm test` now passes end to end for the first time since the eslint 8.4 → 10.5 bump: **0 lint findings, 10 tests passing.**

Two more latent bugs fell out of this.

## `get-data.js` threw a ReferenceError on every reverse-association column

```js
var joinedCriteria = _.split(column.data, '.', 2)[1];
if (_.isUndefined(joinCriteria)) { ... } else { _reverse[joinCriteria] = ... }
```

It assigned `joinedCriteria` and read **`joinCriteria`** — no `ed` — twice. That name is declared nowhere, and reading an undeclared name *throws* rather than yielding `undefined`. So any DataTables column configured with `reverse` 500'd instead of filtering. `no-undef` is off for backend code, and the unused assignment was the only trace it left.

## `inquire.js:getSchemaVersion` was a guaranteed no-op

It built its `questions` array and returned — never prompting, never calling `next`. Its sibling `getBackupInfo` ends with the `inquirer.prompt(questions).then(next)` this was missing. Nothing calls it today (`tools/migrate/index.js` uses only `getBackupInfo`), which is why it went unnoticed.

## `no-unused-vars` (97)

Beyond those two: 44 dead declarations (mostly `let res = this.res;` in actions that never touch `res`, plus unused requires and leftovers like `orig`/`toRem`), 43 trailing parameters, and 8 unused catch bindings renamed to `unusedErr` per the `caughtErrorsIgnorePattern` already configured.

All 43 params were flagged under the rule's default `args: 'after-used'`, which only reports parameters *following the last used one* — so removing them cannot shift any argument position. Mostly Sails' `inputs` in actions that read `this.req` instead; `general/update.js` already used the bare `fn: async function()` form, so this follows existing practice.

`dashboard.js` kept `bandwidthinterval` and `bandwidthajax` as write-only bindings — assigned, never read, no teardown anywhere. Dropped the bindings *and* the assignments: deleting only the declarations would have turned those assignments into implicit globals, which is the same bug fixed in `hwinfo.js` in #92.

## `camelcase` (20) — split by whether it's style drift or wire format

**Renamed** (purely internal): `db_uri`, `jwt_payload`, and `network_ifaces` / `default_iface` in `hwinfo.js` — neither appears in that helper's return value.

**Kept** (keys in JSON this app serves): `default_iface` from `/bandwidth`, and the `tx_`/`rx_` set under `/system/info`. The latter also mirror `systeminformation`'s own field names, so the snake_case is deliberate at both ends. Renaming them would be a breaking API change for cosmetic reasons, so the rule now carries an `allow` list for exactly those. In `bandwidth.js` the local becomes `defaultIface` and the key is written out explicitly (`default_iface: defaultIface`) so the wire format is visible rather than implied by a shorthand property.

## `no-redeclare` (2)

- `get-data.js` declared `var order` twice for unrelated jobs — the default order options and, 37 lines later, the sort accumulator. Second renamed `sortOrder`; `_options.order` holds a reference taken before the reassignment, so nothing observable changes.
- `routes.test.js` declared `var request` twice. Both hoist to **one** binding, and the describe body runs before any `it` — so every request in the file already used the second, authenticated hook. Renaming would have changed which tests send an Authorization header, so I dropped the `var` instead, matching `hook` on the line above. Behaviour identical.

## Left alone

`views/pages/partials/login.js` is an empty IIFE that does nothing at all. Pre-existing dead code, left in place; only its unused `$` parameter was removed.

## Verification

- `npm test` green: 0 findings, 10 passing
- `grunt build` clean through babel, `layout.ejs` unchanged
- `getMigrations()` A/B'd against master again across all eight upgrade/downgrade/no-op/missing cases
- `/bandwidth` and `/system/info` response keys confirmed intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)